### PR TITLE
Add CI: run the test suite automatically on PRs (and live-data checks nightly)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,16 +32,17 @@ jobs:
       run:
         shell: bash -el {0}   # login shell so `conda activate` works
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up conda (environment-test.yml)
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           environment-file: requirements/environment-test.yml
           activate-environment: nbs_env_test
           miniforge-version: latest
+          channels: conda-forge
+          channel-priority: strict
           conda-remove-defaults: true
-          use-only-tar-bz2: false
 
       - name: Show resolved environment
         run: conda list
@@ -60,14 +61,16 @@ jobs:
       run:
         shell: bash -el {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up conda (environment-test.yml)
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           environment-file: requirements/environment-test.yml
           activate-environment: nbs_env_test
           miniforge-version: latest
+          channels: conda-forge
+          channel-priority: strict
           conda-remove-defaults: true
 
       - name: Run network tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,9 @@ name: tests
 # (environment-test.yml — no TensorFlow). Two jobs:
 #   * test    — fast, deterministic suite on every PR / push to main. Gates merges.
 #   * network — the live NOAA/AWS reachability tests, on a daily schedule only,
-#               so an upstream outage never blocks a PR.
+#               so an upstream outage never blocks a PR. On failure it opens a
+#               (de-duplicated) tracking issue so the team hears about upstream
+#               changes without watching the Actions tab.
 
 on:
   push:
@@ -57,6 +59,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     name: network tests (scheduled)
     runs-on: ubuntu-latest
+    # Needed by the failure step below so the built-in token can open an issue.
+    permissions:
+      contents: read
+      issues: write
     defaults:
       run:
         shell: bash -el {0}
@@ -75,3 +81,40 @@ jobs:
 
       - name: Run network tests
         run: pytest tests/ -m network -v
+
+      # If the live tests failed, surface it as a tracked issue so the team
+      # hears about upstream changes (URL move, bucket rename, API drift)
+      # without anyone having to watch the Actions tab. De-duplicated: a single
+      # open issue covers a multi-day outage rather than one issue per night.
+      - name: Open an issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Ensure the tracking label exists (no-op if it already does).
+          gh label create network-test-failure \
+            --color B60205 \
+            --description "Scheduled live NOAA/AWS network test failed" 2>/dev/null || true
+
+          # Skip if an open issue with this label already exists (anti-spam).
+          existing=$(gh issue list --label network-test-failure --state open \
+            --json number --jq 'length')
+          if [ "${existing:-0}" -ne 0 ]; then
+            echo "An open network-test-failure issue already exists; not creating a duplicate."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "🔴 Scheduled network test failed ($(date -u +%Y-%m-%d))" \
+            --label network-test-failure \
+            --body "The scheduled \`network\` job failed. Upstream NOAA AWS (\`noaa-cfs-pds\`) or NCEI may have changed — e.g. a URL move, bucket rename, or API-shape drift — or it could be a transient outage.
+
+          **Run log:** ${RUN_URL}
+
+          To investigate locally:
+          \`\`\`bash
+          pytest tests/ -m network -v
+          \`\`\`
+
+          Close this issue once the cause is resolved; the next failure will open a fresh one."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,74 @@
+name: tests
+
+# Runs the automated test suite on a lightweight conda environment
+# (environment-test.yml — no TensorFlow). Two jobs:
+#   * test    — fast, deterministic suite on every PR / push to main. Gates merges.
+#   * network — the live NOAA/AWS reachability tests, on a daily schedule only,
+#               so an upstream outage never blocks a PR.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # 07:13 UTC daily — off the top of the hour on purpose.
+    - cron: "13 7 * * *"
+  workflow_dispatch: {}
+
+# A newer push to the same branch cancels an in-flight run.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # Deterministic suite: everything except the live-network tests.
+    # Skipped on the scheduled trigger (that's the network job's slot).
+    if: github.event_name != 'schedule'
+    name: unit tests (no network)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}   # login shell so `conda activate` works
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up conda (environment-test.yml)
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          environment-file: requirements/environment-test.yml
+          activate-environment: nbs_env_test
+          miniforge-version: latest
+          conda-remove-defaults: true
+          use-only-tar-bz2: false
+
+      - name: Show resolved environment
+        run: conda list
+
+      - name: Run tests (excluding network)
+        run: pytest tests/ -m "not network" -v
+
+  network:
+    # Live NOAA AWS / NCEI reachability. Scheduled (and manually dispatchable)
+    # only — never on PRs. A red run here means "upstream data moved/outage",
+    # which is worth knowing but must not block development.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: network tests (scheduled)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up conda (environment-test.yml)
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          environment-file: requirements/environment-test.yml
+          activate-environment: nbs_env_test
+          miniforge-version: latest
+          conda-remove-defaults: true
+
+      - name: Run network tests
+        run: pytest tests/ -m network -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,33 @@ Following this naming convention will make it easier to identify the purpose of 
 
 ### Unit Tests
 
-For now, run tests with `pytest -q` from repo root.
+Run tests with `pytest -q` from the repo root.
+
+Tests that reach live external endpoints (NOAA AWS / NCEI) are marked
+`@pytest.mark.network`. To run only the offline, deterministic suite:
+
+```bash
+pytest -m "not network"
+```
+
+To run only the live-network checks:
+
+```bash
+pytest -m network
+```
+
+#### Continuous integration
+
+On every pull request to `main`, GitHub Actions builds a lightweight conda
+environment from `requirements/environment-test.yml` (the full
+`environment.yml` minus the TensorFlow stack, which no test imports) and runs
+`pytest -m "not network"`. The live-network tests run on a daily schedule
+instead, so an upstream NOAA/AWS outage never blocks a PR. The CI suite grows
+automatically as new test files land on `main` — no workflow changes needed.
+
+If you bump a pinned version (`scikit-learn`, `cfgrib`, `joblib`, `python`) in
+`environment.yml`, update `requirements/environment-test.yml` to match;
+`tests/unit/test_environment.py` asserts the two stay in sync.
 
 ### Documentation Styleguide
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+# Tests live under tests/; src/ is importable via tests/conftest.py.
+testpaths = ["tests"]
+markers = [
+    "network: test reaches live external endpoints (NOAA AWS / NCEI). Excluded from the default CI run; exercised on a schedule instead. Run locally with `pytest -m network`.",
+]

--- a/requirements/environment-test.yml
+++ b/requirements/environment-test.yml
@@ -1,0 +1,46 @@
+---
+# Lightweight environment for running the automated test suite (CI).
+#
+# This is environment.yml with the TensorFlow/Keras pip stack and
+# notebook-only tooling removed. Nothing under src/ or tests/ imports
+# TensorFlow — model inference uses scikit-learn models loaded via joblib —
+# so CI does not need to build the heavy (and Windows-finicky) TF stack.
+#
+# Pins are kept IN SYNC with environment.yml on purpose: tests/unit/
+# test_environment.py asserts the installed versions of cfgrib,
+# scikit-learn, joblib and the Python interpreter match the pins below.
+# If you bump a pin in environment.yml, bump it here too (and vice versa).
+#
+# Training new models still requires the full environment.yml.
+name: nbs_env_test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python==3.12.3
+  - scipy
+  - scikit-learn==1.7.0
+  - beautifulsoup4
+  - boto3
+  - botocore
+  - cfgrib==0.9.15.0
+  - pandas
+  - netcdf4
+  - numpy
+  - joblib==1.5.2
+  - matplotlib
+  - pillow
+  - plotly
+  - properscoring
+  - pytest
+  - requests
+  - requests-toolbelt
+  - setuptools
+  - sqlite
+  - tabulate
+  - urllib3
+  - zlib
+  - pyyaml
+  - xarray
+  - xgboost
+  - pip

--- a/requirements/environment-test.yml
+++ b/requirements/environment-test.yml
@@ -15,7 +15,6 @@
 name: nbs_env_test
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python==3.12.3
   - scipy

--- a/tests/unit/test_data_inputs.py
+++ b/tests/unit/test_data_inputs.py
@@ -1,4 +1,9 @@
 # To test use "pytest --capture=no test_data_inputs.py"
+#
+# Every test in this module reaches live external endpoints (NOAA AWS S3 /
+# NCEI). They are marked `network` so the default CI run can exclude them
+# (`pytest -m "not network"`); a scheduled job exercises them separately so a
+# NOAA outage never blocks a PR. Run locally with `pytest -m network`.
 
 import requests
 import boto3
@@ -11,6 +16,9 @@ import os
 import sys
 sys.path.append(os.path.abspath('../../'))
 from src.data_downloader import CFSDownloader
+
+# Applies to every test in this module — see header note.
+pytestmark = pytest.mark.network
 
 class TestURLAvailability:
 


### PR DESCRIPTION
We have a growing pytest suite across several branches but nothing runs it automatically. This wires up GitHub Actions to run the tests on every PR to main, so problems are caught at the boundary instead of by hand.

This deliberately does not resurrect the old environment-build check. That check asked an unanswerable question ("can we rebuild the user's exact Windows runtime?") and produced red that we learned to ignore. This asks an actionable one: do the tests pass on a clean checkout?

**How it works**

- test job: on every PR and push to main. Builds a lightweight conda env (`requirements/environment-test.yml`) and runs `pytest -m "not network"`. This is the gate.
- network job: on a daily schedule (and manual dispatch) only. Runs the live NOAA/AWS reachability tests (`pytest -m network`). A NOAA outage will never block a PR, but we still find out if an endpoint moves.

**Key design choices**

- No TensorFlow in CI. Nothing under src/ or tests/ imports TF: model inference uses scikit-learn models loaded via joblib. So environment-test.yml is environment.yml minus the TF/Keras stack, sidestepping the finicky tensorflow-intel Windows stub. Training still uses the full `environment.yml`.
- Pins kept in sync. test_environment.py asserts scikit-learn, cfgrib, joblib, and python versions. environment-test.yml matches those pins exactly; a note in CONTRIBUTING.md flags the sync requirement.
- The suite grows itself. CI runs pytest, not a hardcoded list: as the issue 038/039/040 test PRs merge into main, their tests are picked up automatically with no workflow change.
- Linux only, no OS matrix (we decided Windows env-building is noise. It's more meaningful if USACE is able to tell us about problems directly).

**Files**

- `.github/workflows/tests.yml`: the two-job workflow
- `requirements/environment-test.yml`: lightweight CI env (no TF)
- `pyproject.toml`: registers the network marker, sets testpaths
- `tests/unit/test_data_inputs.py` : +8 lines: `module-level pytestmark = pytest.mark.network` (the whole file hits live endpoints)
- `CONTRIBUTING.md`: documents the markers and CI behavior

**Verified locally**

- `pytest -m "not network"` on main's current tests leads to 4 passed, 4 deselected (grows as PRs merge)
- `environment-test.yml` contains every package `test_environment.py` requires, all four version pins match

**The real test is this PR's own CI run** 

Once I make this PR, the first CI run on this PR is the actual proof. If the env build fails, that's the thing to fix; everything downstream of environment construction is verified.