### PR TITLE
docs: Sphinx polish, full docstring coverage, version/horizon fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 ## Overview
-Welcome to nbs-predictor! This software package is designed to forecast key components of Net Basin Supply (NBS) for the Laurentian Great Lakes using atmospheric forecast data. At present, it uses NOAA's Climate Forecast System (CFS) data to forecast precipitation, evaporation, and runoff nine months into the future at monthly intervals.
+Welcome to nbs-predictor! This software package is designed to forecast key components of Net Basin Supply (NBS) for the Laurentian Great Lakes using atmospheric forecast data. At present, it ingests NOAA's Climate Forecast System (CFS) data—which extends roughly nine months into the future—to forecast precipitation, evaporation, runoff, and NBS out to twelve months at monthly intervals.
 
 ### Features
 - Advanced Predictive Algorithms: Leverages methods like Gaussian Processes for data-driven forecasting.

--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@
 </p>
 
 ## Overview
-Welcome to nbs-predictor! This software package is designed to forecast key components of Net Basin Supply (NBS) for the Laurentian Great Lakes using atmospheric forecast data. At present, it ingests NOAA's Climate Forecast System (CFS) data—which extends roughly nine months into the future—to forecast precipitation, evaporation, runoff, and NBS out to twelve months at monthly intervals.
+Welcome to nbs-predictor! This software package is designed to forecast key components of **Net Basin Supply (NBS)** for the Laurentian Great Lakes using atmospheric forecast data. Currently, the package uses forecast data from National Oceanic and Atmospheric Administration’s Climate Forecast System (CFS) to predict **precipitation**, **evaporation**, **runoff**, and **net basin supply (NBS)** at monthly intervals up to **12 months** into the future.
 
 ### Features
-- Advanced Predictive Algorithms: Leverages methods like Gaussian Processes for data-driven forecasting.
-- Real-Time Data Processing: Integrates live forecast data for up-to-date predictions.
-- User-Friendly Interface: Streamlined setup and interactive notebooks for ease of use.
-- Continuous Improvements: Regular updates to enhance features, performance, and modeling capabilities.
-
-### Targets
-Forecast precipitation (P), evaporation (E), runoff (R), and net basin supply (NBS) for all of the Laurentian Great Lakes up to twelve (12) months into the future at monthly intervals. By forecasting NBS directly, rather than deriving it from the individual component forecasts—we reduce the accumulation of error and improve overall forecast reliability.
+- **Advanced Predictive Algorithms:** Leverages methods like Gaussian Processes and Random Forest for data-driven forecasting.
+- **Real-Time Data Processing:** Processes ureal time operational forecast data for up-to-date predictions.
+- **User-Friendly Interface:** Streamlined setup and interactive notebooks for ease of use.
+- **Continuous Improvements:** Actively maintained with regular updates to improve performance, expand functionality, and enhance modeling capabilities.
 
 ### Inputs
-- Data Source: NOAA forecast data from the Climate Forecast System (CFS), which must be downloaded and preprocessed before generating forecasts. Additionally, sea surface temperatures from GLSEA are required as initial conditions. This repository includes notebooks to handle both downloading and preprocessing of both datasets. 
-- Required Datasets: Please refer to the 'Data Sources' section below for specific files and data organization.
+- **Data Source:** NOAA forecast data from the Climate Forecast System (CFS), which must be downloaded and preprocessed before generating forecasts. Additionally, sea surface temperatures from GLSEA are required as initial conditions. This repository includes notebooks to handle both downloading and preprocessing of both datasets. 
+- **Required Datasets:** Please refer to the 'Data Sources' section below for specific files and data organization.
+
+### Targets
+Forecast monthly **precipitation (P), evaporation (E), runoff (R), and net basin supply (NBS)** for all of the Laurentian Great Lakes twelve (12) months into the future. By forecasting NBS directly, rather than deriving it solely from the individual component forecasts `(NBS = P − E + R)`, the model minimizes accumulated uncertainty and improves reliability.
 
 ### Data Sources
 
@@ -31,8 +31,8 @@ Forecast precipitation (P), evaporation (E), runoff (R), and net basin supply (N
 | CFSR         | Climate Forecast System Reanalysis             | NOAA           | Training       |
 | CFS          | Climate Forecast System v2                     | NOAA           | Forecasting    |
 | GLSEA        | Great Lakes Surface Environmental Analysis     | NOAA GLERL     | Forecasting |
-| LS2SWBM      | Large Lake Statistical Water Balance Model     | NOAA GLERL     | Training    |
-| GLCC         | Great Lakes Coordinating Committee             |                | Training |
+| L2SWBM       | Large Lake Statistical Water Balance Model     | NOAA GLERL     | Training    |
+| GLCC         | Great Lakes Coordinating Committee             | USACE / ECCC   | Training |
 
 
 ## Getting Started
@@ -101,32 +101,54 @@ jupyter lab
 
 ```graphql
 cnbs-predictor/
+├── assets                                      # Project logos and branding assets
+├── CITATION.cff                                # Citation metadata for the project
 ├── CODE_OF_CONDUCT.md                          # Code of conduct for contributors
-├── CONTRIBUTING.md                             # Project license
-├── data                                        # Directory for storing input data
+├── CONTRIBUTING.md                             # Contribution guidelines
+├── data                                        # Directory for storing input and forecast data
 │   ├── cfs                                     # Archived pre-processed CFS data
-|   ├── cfsr                                    # Archived pre-processed CFSR data used for training
-│   ├── glcc                                    # NBS Observations from GLCC used for training and validation
-│   ├── glsea                                   # GLSEA Sea Surface Temperatures for the Great Lakes
-│   ├── input                                   # Model inputs for forecasting (ML models, scalers, masks, etc.)
-│   ├── l2swbm                                  # L2SWBM target data (P, E, R)
-│   ├── probabilities                           # Probability files from USACE (update as needed)
-│   ├── snodas                                  # SNODAS file from USACE (update as needed)
-├── docs                                        # Documents
-├── forecast                                    # Folder to save the forecast output
+│   ├── cfsr                                    # Archived pre-processed CFSR data used for training
+│   ├── forecast                                # Forecast output data
+│   ├── glcc                                    # NBS observations from GLCC used for training and validation
+│   ├── glsea                                   # GLSEA surface water temperature data
+│   ├── input                                   # Model inputs, trained models, scalers, masks, etc.
+│   ├── l2swbm                                  # L2SWBM target data for precipitation, evaporation, and runoff
+│   ├── probabilities                           # USACE probability files used for CEP calculations
+│   └── snodas                                  # SNODAS snow data used for model inputs
+├── docs                                        # Project documentation and supporting materials
+│   ├── development_history.md                  # Notes on project development and changes
+│   ├── experiment_skill_metrics.md             # Skill metric summaries from model experiments
+│   ├── experiments.md                          # Experiment descriptions and results
+│   ├── Great Lakes NBS Predictor Flyer.pdf     # Project flyer
+│   ├── sphinx                                  # Sphinx documentation source files
+│   └── wiki-drafts                             # Draft content for GitHub wiki pages
+├── images                                      # Team member or project-related images
 ├── LICENSE                                     # Project license
 ├── notebooks                                   # Jupyter notebooks
-│   ├── exploratory                             # Initial exploration and additionally helpful notebooks
-│   ├── production                              # Production-ready notebooks (use these to produce forecasts)
-│   └── validation                              # Notebooks used for verification and validation
-├── README.md                                   # Project README file
-├── requirements                                # Conda environment requirements
-├── ROADMAP.md                                  # Release schedule and CI/CD implementation plan
-├── src                                         # Source code for data processing and utilities
-└── tests                                       # Tests for the codebase
-    ├── integration                             # Integration tests for testing multiple components
-    └── unit                                    # Unit tests for quick testing of functions and data availability
-```
+│   ├── exploratory                             # Exploratory and development notebooks
+│   ├── production                              # Production-ready notebooks for generating forecasts
+│   └── validation                              # Notebooks for model validation
+├── README.md                                   # Project overview and setup instructions
+├── requirements                                # Conda environment files
+│   ├── environment-test.yml                    # Testing environment
+│   └── environment.yml                         # Main project environment
+├── ROADMAP.md                                  # Project roadmap and planned improvements
+├── SECURITY.md                                 # Security policy and reporting guidance
+├── src                                         # Source code for data processing, modeling, and utilities
+│   ├── data_downloader.py                      # Utilities for downloading input datasets
+│   ├── data_loader.py                          # Functions for loading data
+│   ├── data_processor.py                       # Data cleaning, transformation, and preprocessing tools
+│   ├── database_utils.py                       # Database creation, querying, and management utilities
+│   ├── forecast_smoke.py                       # Forecast smoke tests or quick forecast checks
+│   ├── hydro_utils.py                          # Hydrologic calculation utilities
+│   ├── plotting.py                             # Plotting and visualization functions
+│   └── utilities.py                            # General helper functions
+└── tests                                       # Test suite
+    ├── conftest.py                             # Shared pytest fixtures and configuration
+    ├── fixtures                                # Test fixture data
+    ├── integration                             # Integration tests across multiple components
+    └── unit                                    # Unit tests for individual functions
+    ```
 
 ## Contributing
 We welcome contributions to cnbs-predictor! Please start a discussion with the maintainers first (@lefitzpatrick, @danijonesocean), preferably in the GitHub Discussions or Issues sections of this repository. Once you have discussed possible changes with the developers:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Welcome to nbs-predictor! This software package is designed to forecast key comp
 
 ### Features
 - **Advanced Predictive Algorithms:** Leverages methods like Gaussian Processes and Random Forest for data-driven forecasting.
-- **Real-Time Data Processing:** Processes ureal time operational forecast data for up-to-date predictions.
+- **Real-Time Data Processing:** Processes real-time operational forecast data for up-to-date predictions.
 - **User-Friendly Interface:** Streamlined setup and interactive notebooks for ease of use.
 - **Continuous Improvements:** Actively maintained with regular updates to improve performance, expand functionality, and enhance modeling capabilities.
 

--- a/docs/sphinx/api/forecast_smoke.rst
+++ b/docs/sphinx/api/forecast_smoke.rst
@@ -1,0 +1,7 @@
+forecast_smoke
+==============
+
+.. automodule:: src.forecast_smoke
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/sphinx/api/index.rst
+++ b/docs/sphinx/api/index.rst
@@ -13,6 +13,7 @@ docstrings.
    data_loader
    data_processor
    database_utils
+   forecast_smoke
    hydro_utils
    plotting
    utilities

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -22,7 +22,7 @@ sys.path.insert(0, REPO_ROOT)
 project = "cnbs-predictor"
 author = "Great Lakes AI Lab"
 copyright = f"{datetime.now():%Y}, {author}"
-release = "0.1"
+release = "1.2.0"
 
 # -- General configuration ---------------------------------------------------
 extensions = [
@@ -74,6 +74,7 @@ autodoc_mock_imports = [
     "joblib",
     "matplotlib",
     "plotly",
+    "cartopy",
     "properscoring",
     "bs4",
     "requests_toolbelt",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,8 @@
+"""Core library for the Great Lakes Net Basin Supply (NBS) forecast tool.
+
+The ``src`` package provides the building blocks used by the production
+notebooks: downloading CFS forecast and GLSEA data, processing GRIB files into
+lake-averaged variables, transforming and feature-engineering that data,
+generating NBS forecasts with trained models, computing exceedance
+probabilities, and plotting results. See the individual modules for details.
+"""

--- a/src/data_downloader.py
+++ b/src/data_downloader.py
@@ -1,3 +1,17 @@
+"""Downloaders for the forecast tool's external input data.
+
+Provides two classes:
+
+- :class:`CFSDownloader` retrieves Climate Forecast System v2 (CFSv2) GRIB2
+  forecast files from either the NOAA AWS public dataset or the NOAA NCEI
+  archive, organising them into per-date local subdirectories.
+- :class:`SSTDownloader` fetches Great Lakes surface water temperatures from
+  NOAA GLSEA ``.dat`` files, used as initial conditions for forecasting.
+
+Network access is required at run time; the heavy I/O dependencies (boto3,
+requests, BeautifulSoup) are mocked when building the documentation.
+"""
+
 import os
 import urllib.request
 import requests
@@ -305,7 +319,18 @@ class CFSDownloader:
             print(f"ERROR downloading from NCEI: {e}")
 
 class SSTDownloader:
+    """Download Great Lakes surface water temperatures from NOAA GLSEA.
+
+    GLSEA (Great Lakes Surface Environmental Analysis) publishes daily
+    lake-averaged surface water temperatures as plain-text ``.dat`` files.
+    This class parses those files into tidy, per-lake :class:`pandas.DataFrame`
+    objects (Superior, Michigan-Huron, Erie, Ontario) for use as forecast
+    initial conditions, with optional unit conversion and climatology
+    backfilling of missing dates.
+    """
+
     def __init__(self):
+        """Initialize the SSTDownloader. No configuration is required."""
         pass
 
     def current_glsea(self, url, units='K'):

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,3 +1,20 @@
+"""Loaders for observed and training datasets used by the forecast tool.
+
+This module reads the various on-disk datasets the model is trained and
+validated against, returning each as a tidy, date-indexed
+:class:`pandas.DataFrame`:
+
+- **GLCC** observed Net Basin Supply (:meth:`DataLoader.glcc`)
+- **L2SWBM** precipitation, evaporation, and runoff (:meth:`DataLoader.l2swbm`)
+- **GLSEA** lake surface temperatures (:meth:`DataLoader.glsea`)
+- **SNODAS** snow water equivalent (:meth:`DataLoader.snodas`)
+- USACE probability-of-exceedance tables (:meth:`DataLoader.lake_probabilities`)
+
+Several loaders accept a ``units`` argument and convert between cubic metres
+per second (``cms``) and millimetres per month (``mm``) using the per-lake
+surface areas in :data:`lake_areas`.
+"""
+
 import pandas as pd
 import numpy as np
 import calendar
@@ -12,7 +29,15 @@ lake_areas = {
 }
 
 class DataLoader:
+    """Load the observed and training datasets used to fit and validate models.
+
+    Each method reads one dataset family from a local directory and returns a
+    cleaned, date-indexed :class:`pandas.DataFrame`. The loader is stateless;
+    all paths and options are passed per call.
+    """
+
     def __init__(self):
+        """Initialize the DataLoader. No configuration is required."""
         pass
 
     def glcc(self, directory, units='cms'):
@@ -238,6 +263,7 @@ class DataLoader:
         file_dir : str
             Path to the directory containing the lake probability CSV files.
             Expected files are:
+
             - SUP.probs.csv  (Lake Superior)
             - MIH.probs.csv  (Lakes Michigan-Huron)
             - ERI.probs.csv  (Lake Erie)
@@ -245,14 +271,16 @@ class DataLoader:
 
         units : str, optional, default="cms"
             Desired output units for flow values.
+
             - "cms" : cubic meters per second (original units from source files)
             - "mm"  : millimeters per month, computed using lake surface area
-                    and number of days in each month.
+              and number of days in each month.
 
         Returns
         -------
         pandas.DataFrame
             A tidy DataFrame containing columns:
+
             - "month" : str, calendar month (Jan–Dec)
             - "lake" : str, lake name ("superior", "michigan-huron", "erie", "ontario")
             - "prob_exceedance" : float, probability of exceedance (0.99–0.01)
@@ -260,11 +288,11 @@ class DataLoader:
 
         Notes
         -----
-        - When units="mm", values are converted from m³/s to mm/month using:
-            value_mm = value_cms * 1000 * 86400 * days_in_month / lake_area
-            where lake_area is the surface area of each lake in m².
+        - When units="mm", values are converted from m³/s to mm/month using
+          ``value_mm = value_cms * 1000 * 86400 * days_in_month / lake_area``,
+          where ``lake_area`` is the surface area of each lake in m².
         - Input CSVs are assumed to have 7 header rows before the data block,
-        and contain a column named "Probability Of Exceedance".
+          and contain a column named "Probability Of Exceedance".
 
         Example
         -------

--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -1,3 +1,28 @@
+"""Core processing, transformation, and forecasting logic for CFS data.
+
+This module is the heart of the ``src`` package. It turns raw CFS GRIB files
+into lake-averaged variables and runs them through trained models to produce
+NBS forecasts. The main components are:
+
+- :class:`CFSProcessor` — read CFS GRIB files, remap to the basin mask, and
+  store lake/land-averaged precipitation, temperature, and evaporation.
+- :class:`SeasonalCycleProcessor` — fit a monthly climatology and convert
+  between absolute values and anomalies (including lead-wide helpers).
+- :class:`CFSTransformer` — reshape and feature-engineer the processed data
+  (filtering, lag/lead shifts, wide-format structuring, time features).
+- :class:`CNBSForecaster` — load trained models and scalers and generate
+  forecasts in either absolute or anomaly mode.
+- :class:`ForecastTransformer` — reshape forecast output between wide and
+  long/tidy formats and filter by forecast month.
+- :class:`CEPCalculator` — compute Climatology Exceedance Probabilities from
+  forecasts and probability-of-exceedance curves.
+- :func:`calculate_acc_variables` — accumulate forecast values over multi-month
+  windows.
+
+Heavy dependencies (cfgrib, netCDF4, xarray, scikit-learn, properscoring) are
+imported at module scope and mocked when building the documentation.
+"""
+
 import os
 import pandas as pd
 import cfgrib
@@ -18,6 +43,21 @@ from src.database_utils import CFSDatabase
 from src.hydro_utils import calculate_evaporation_rate, calculate_grid_cell_areas
 
 class CFSProcessor:
+    """Process downloaded CFS GRIB files into lake-averaged variables.
+
+    Reads CFS forecast GRIB2 files for a run, remaps the relevant fields
+    (precipitation, 2-metre air temperature, evaporation from latent heat
+    flux) onto a basin mask grid, computes area-weighted lake/land averages,
+    and writes the results to the forecast database via :class:`CFSDatabase`.
+
+    Parameters
+    ----------
+    database : str
+        Path to the SQLite database file used for output.
+    table : str
+        Name of the table to write processed values into.
+    """
+
     def __init__(self, database, table):
         """
         Initialize the processor with database path and table name.
@@ -396,16 +436,13 @@ class SeasonalCycleProcessor:
             If None, all numeric columns are used.
 
         baseline_time : slice, optional
-            Time slice applied before computing climatology.
-            Example:
-                slice("1981-01-01", "2008-12-01")
-
-            If None, full DataFrame is used.
+            Time slice applied before computing climatology, e.g.
+            ``slice("1981-01-01", "2008-12-01")``. If None, the full DataFrame
+            is used.
 
         baseline_definition : dict, optional
-            Metadata describing baseline choice (for reproducibility).
-            Example:
-                {"train_start": "1981-01-01", "train_end": "2008-12-01"}
+            Metadata describing baseline choice (for reproducibility), e.g.
+            ``{"train_start": "1981-01-01", "train_end": "2008-12-01"}``.
 
         Returns
         -------
@@ -541,11 +578,8 @@ class SeasonalCycleProcessor:
         Returns
         -------
         dict
-            Dictionary containing:
-                {
-                    "climatology_path": <path>,
-                    "metadata_path": <path>
-                }
+            Dictionary containing the keys ``"climatology_path"`` and
+            ``"metadata_path"``, each mapping to the path of the written file.
         """
 
         if self.climatology is None:
@@ -737,17 +771,15 @@ class SeasonalCycleProcessor:
 
         For each column:
 
-        1. The forecast lead month is extracted using the `_mo{k}` suffix.
+        1. The forecast lead month is extracted using the ``_mo{k}`` suffix.
         2. The base variable name is identified by removing the suffix.
         3. The verifying month is computed by shifting the initialization date
-        forward by the forecast lead.
-        4. The corresponding monthly climatology is subtracted from the forecast
-        value.
+           forward by the forecast lead.
+        4. The corresponding monthly climatology is subtracted from the
+           forecast value.
 
-        The verifying month is calculated as:
-
-            verifying_month =
-                initialization_date + forecast_lead_months
+        The verifying month is calculated as
+        ``verifying_month = initialization_date + forecast_lead_months``.
 
         This ensures that climatology subtraction is aligned with the actual
         target month being forecasted rather than the initialization month.
@@ -916,6 +948,21 @@ class SeasonalCycleProcessor:
         return scp_X, scp_y
 
 class CFSTransformer:
+    """Reshape and feature-engineer processed CFS data for modelling.
+
+    Wraps a :class:`pandas.DataFrame` of processed CFS values and provides
+    transformations used to build the model input matrix: filtering to recent
+    runs (:meth:`filter`), creating lagged/lead columns
+    (:meth:`shift_variables`), pivoting long data into the wide per-lead
+    feature layout (:meth:`structure_input`), and adding cyclical month and
+    time-trend features (:meth:`add_time_features`).
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The processed CFS data to transform. Copied on construction.
+    """
+
     def __init__(self, df):
         """
         Initialize the transformer with a pandas DataFrame.
@@ -1229,6 +1276,25 @@ class CFSTransformer:
         return out
         
 class CNBSForecaster:
+    """Load trained models and scalers and generate NBS forecasts.
+
+    On construction, loads the input/output scalers and all trained models
+    found in the given directories, selecting the ``_anom`` artifacts when
+    ``mode='anomaly'``. :meth:`predict` runs a named model over a feature
+    matrix and returns a forecast DataFrame, converting anomalies back to
+    absolute values when operating in anomaly mode.
+
+    Parameters
+    ----------
+    model_dir : str
+        Directory containing the trained model ``.joblib`` files.
+    scaler_dir : str
+        Directory containing the input/output scaler ``.joblib`` files.
+    mode : str, default "actual"
+        Either ``"actual"`` (absolute values) or ``"anomaly"`` (anomalies
+        relative to climatology).
+    """
+
     def __init__(self, model_dir, scaler_dir, mode="actual"):
         """
         Initialize the ForecastModel class.
@@ -1290,6 +1356,21 @@ class CNBSForecaster:
             )
 
     def _load_models(self, suffix):
+        """
+        Load all trained models matching the given filename suffix.
+
+        Parameters
+        ----------
+        suffix : str
+            Suffix selecting the model variant (e.g. ``""`` for absolute or
+            ``"_anom"`` for anomaly models). Files named
+            ``{name}_trained_model{suffix}.joblib`` are loaded.
+
+        Returns
+        -------
+        dict
+            Mapping of model name to the deserialized model object.
+        """
         models = {}
         for file in os.listdir(self.model_dir):
             if file.endswith(f"_trained_model{suffix}.joblib"):
@@ -1710,13 +1791,11 @@ def calculate_acc_variables(
     data by `forecast_month` and sums the first N forecast months for each
     requested accumulation period.
 
-    For example:
-        accumulation_periods=(1, 3, 6)
+    For example, ``accumulation_periods=(1, 3, 6)`` will create:
 
-    will create:
-        variable_acc1 = month 1
-        variable_acc3 = months 1-3 summed
-        variable_acc6 = months 1-6 summed
+    - ``variable_acc1`` = month 1
+    - ``variable_acc3`` = months 1-3 summed
+    - ``variable_acc6`` = months 1-6 summed
 
     Parameters
     ----------

--- a/src/database_utils.py
+++ b/src/database_utils.py
@@ -1,3 +1,14 @@
+"""SQLite storage for processed CFS forecast data.
+
+Wraps a single SQLite database/table behind :class:`CFSDatabase`, providing
+schema creation, row- and DataFrame-level inserts, point lookups, and helpers
+for figuring out which forecast run to download next. The schema keys each
+value by ``(cfs_run, year, month, lake, surface_type, component)``.
+
+The forecast notebooks use this module to persist processed CFS output and to
+resume incremental downloads where the previous run left off.
+"""
+
 import sqlite3
 import os
 import pandas as pd
@@ -8,6 +19,22 @@ from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import relativedelta
 
 class CFSDatabase:
+    """Manage a SQLite database of processed CFS forecast values.
+
+    Each instance is bound to one database file and one table. The table
+    stores one value per ``(cfs_run, year, month, lake, surface_type,
+    component)`` key. Methods cover schema creation, inserting individual
+    records or whole DataFrames, point lookups, and determining the next CFS
+    run to download.
+
+    Parameters
+    ----------
+    database : str
+        Path to the SQLite database file (created if it does not exist).
+    table : str
+        Name of the table to read from and write to.
+    """
+
     def __init__(self, database, table):
         """
         Initialize database connection and ensure table exists.
@@ -42,6 +69,14 @@ class CFSDatabase:
             ''')
 
     def load(self):
+        """
+        Load the entire table into a DataFrame.
+
+        Returns
+        -------
+        pandas.DataFrame
+            All rows of the configured table.
+        """
         # Create a connection to the SQLite database
         conn = sqlite3.connect(self.database)
 
@@ -57,6 +92,33 @@ class CFSDatabase:
         return data
 
     def pull(self, cfs_run, year, month, lake, surface_type, component):
+        """
+        Look up a single stored value by its full primary key.
+
+        Detects whether the table uses a ``value`` or ``value [mm]`` column and
+        queries accordingly.
+
+        Parameters
+        ----------
+        cfs_run : str
+            CFS run identifier (YYYYMMDDHH).
+        year : int
+            Forecast year.
+        month : int
+            Forecast month (1-12).
+        lake : str
+            Lake name.
+        surface_type : str
+            Surface type ('lake' or 'land').
+        component : str
+            NBS component ('precipitation', 'evaporation', 'runoff', 'nbs').
+
+        Returns
+        -------
+        float or None
+            The stored value, or None if no matching row exists or a database
+            error occurs.
+        """
         try:
             conn = sqlite3.connect(self.database)
             cursor = conn.cursor()
@@ -178,11 +240,15 @@ class CFSDatabase:
         """
         Add an entire pandas DataFrame to the database table.
 
-        Parameters:
-        df (pd.DataFrame): The DataFrame to insert. Must contain the columns:
-                           ['cfs_run', 'year', 'month', 'lake', 'surface_type', 'component', 'value']
-        if_exists (str): How to behave if the table already exists.
-                         Options: 'fail', 'replace', 'append' (default).
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The DataFrame to insert. Must contain the columns
+            ``['cfs_run', 'forecast_month', 'model', 'lake', 'precipitation',
+            'evaporation', 'runoff', 'nbs']``.
+        if_exists : str, default "append"
+            How to behave if the table already exists. One of ``'fail'``,
+            ``'replace'``, or ``'append'``.
         """
 
         required_cols = ['cfs_run', 'forecast_month', 'model', 'lake', 'precipitation', 'evaporation', 'runoff', 'nbs']
@@ -201,6 +267,20 @@ class CFSDatabase:
             raise sqlite3.DatabaseError(f"Database error occurred while inserting DataFrame: {e}")
         
     def get_next_run(self):
+        """
+        Determine the next CFS run date to download.
+
+        Reads the most recent ``cfs_run`` in the table and returns the date
+        from which downloading should resume: the same date at midnight if the
+        last run was the 00/06/12 cycle, or the following day if it was the 18
+        cycle. If the table is missing or empty, falls back to the first of the
+        month nine months ago.
+
+        Returns
+        -------
+        datetime.datetime
+            The next run date, with the time component zeroed.
+        """
         try:
             conn = sqlite3.connect(self.database)
             cursor = conn.cursor()
@@ -301,6 +381,12 @@ class CFSDatabase:
         return start_date, end_date, date_array
 
     def print_columns(self):
+        """
+        Print the name and declared type of each column in the table.
+
+        Intended as an interactive/debugging helper; prints a message if the
+        table does not exist or has no columns.
+        """
         try:
             conn = sqlite3.connect(self.database)
             cursor = conn.cursor()

--- a/src/hydro_utils.py
+++ b/src/hydro_utils.py
@@ -1,3 +1,17 @@
+"""Hydrological and unit-conversion helpers for the forecast pipeline.
+
+Small, mostly stateless functions used throughout data processing and
+forecasting:
+
+- time helpers (:func:`seconds_in_month`, :func:`get_first_forecast_month`)
+- grid geometry (:func:`calculate_grid_cell_areas`)
+- physical conversions (:func:`calculate_evaporation_rate`,
+  :func:`convert_mm_to_cms`)
+- model loading (:func:`load_model`)
+
+Lake surface areas and other constants are defined inline where used.
+"""
+
 import calendar
 import numpy as np
 import pandas as pd

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -1,4 +1,20 @@
-# forecast_visualizer.py
+"""Visualization functions for Great Lakes NBS forecast output.
+
+Produces the figures used to inspect and communicate forecast results:
+
+- :func:`plot_cnbs_forecast` — static 4x4 grid (lake x component) of the
+  precipitation, evaporation, runoff, and NBS forecasts with 95% ranges
+- :func:`plot_cnbs_forecast_interactive` — the same grid as an interactive
+  Plotly figure saved to HTML
+- :func:`plot_nbs_forecast` — per-lake NBS forecast with climatology overlay
+- :func:`plot_cep_timeseries` — Climatology Exceedance Probability (CEP)
+  timeseries per lake
+- :func:`plot_cep_spatial` — month-by-month spatial CEP maps over the basin
+
+Each function optionally saves to ``filename`` and otherwise displays the
+figure. The plotting backends (matplotlib, plotly, cartopy) are mocked when
+building the documentation.
+"""
 
 import os
 import pandas as pd
@@ -534,6 +550,36 @@ def plot_cep_spatial(
     cmap="BrBG_r",
     title="Great Lakes 12-Month NBS Climatology Exceedance Outlook"
 ):
+    """
+    Plot a 12-panel spatial map of Climatology Exceedance Probability (CEP).
+
+    Renders one map per forecast month (up to twelve) over the Great Lakes
+    basin, shading each lake polygon by its CEP value on a diverging
+    wetter-to-drier colour scale.
+
+    Parameters
+    ----------
+    df_cep : pd.DataFrame
+        CEP data. Must contain 'forecast_month', 'lake', and the column named
+        by ``value_col`` (and a 'cep' column used for labels).
+    model : str, optional
+        If given, plot only this model. If None, the multi-model mean across
+        models is plotted.
+    value_col : str, default "cep"
+        Column used to colour each lake polygon.
+    filename : str, optional
+        Path to save the figure. If None, the figure is displayed only.
+    cmap : str, default "BrBG_r"
+        Matplotlib colormap name for the diverging wetter/drier scale.
+    title : str, optional
+        Base figure title; the selected model (or "Multi-model Mean") is
+        appended.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The created figure.
+    """
     df = df_cep.copy()
     df["date"] = pd.to_datetime(df["forecast_month"])
     df["lake"] = df["lake"].str.lower().str.strip()

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,3 +1,17 @@
+"""General-purpose helpers shared across the forecast tool.
+
+A grab-bag of small utilities used by the downloaders, processors, and
+notebooks:
+
+- :func:`check_url_exists` — test whether a remote resource is reachable
+- :func:`get_first_forecast_month` — derive the operational forecast month
+  from a reference date
+- :func:`get_date_range` — resolve the start/end dates for a CFS download,
+  either automatically (from the database) or from manual input
+- :func:`create_directory` — create a directory if it does not exist
+- :func:`get_files` — list files in a directory matching a prefix or suffix
+"""
+
 import requests
 from datetime import datetime
 import pandas as pd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Shared pytest configuration: sets up the import path and registers custom markers."""
+
 import sys
 from pathlib import Path
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit test package for the cnbs-predictor project."""

--- a/tests/unit/test_data_inputs.py
+++ b/tests/unit/test_data_inputs.py
@@ -1,9 +1,13 @@
+"""
+Integration tests that verify live availability of upstream CFS data sources.
+
+Every test in this module reaches live external endpoints (NOAA AWS S3 /
+NCEI). They are marked `network` so the default CI run can exclude them
+(`pytest -m "not network"`); a scheduled job exercises them separately so a
+NOAA outage never blocks a PR. Run locally with `pytest -m network`.
+"""
+
 # To test use "pytest --capture=no test_data_inputs.py"
-#
-# Every test in this module reaches live external endpoints (NOAA AWS S3 /
-# NCEI). They are marked `network` so the default CI run can exclude them
-# (`pytest -m "not network"`); a scheduled job exercises them separately so a
-# NOAA outage never blocks a PR. Run locally with `pytest -m network`.
 
 import requests
 import boto3
@@ -24,6 +28,7 @@ pytestmark = [
 ]
 
 class TestURLAvailability:
+    """Checks the AWS and NCEI base endpoints are reachable and unchanged."""
 
     # Test to check AWS and NCEI URL are accessible
     def test_base_url_availability(self):
@@ -144,6 +149,7 @@ class TestCFSDataAvailability:
 
 @pytest.mark.integration
 class TestDataDownloader:
+    """Exercises CFSDownloader.download against the live AWS source."""
 
     def test_cfs_downloader_function(self, tmp_path):
         """

--- a/tests/unit/test_data_loader.py
+++ b/tests/unit/test_data_loader.py
@@ -43,6 +43,8 @@ def _require_files(*paths: Path):
 # glcc — Great Lakes Coordinated Committee monthly NBS, four CSVs
 # ===========================================================================
 class TestGLCCLoader:
+    """Tests the GLCC monthly NBS loader (``DataLoader.glcc``) against shipped CSVs."""
+
     LAKE_FILES = [
         "LakeSuperior_MonthlyNetBasinSupply_1900to2025.csv",
         "LakeMichiganHuron_MonthlyNetBasinSupply_1900to2025.csv",
@@ -58,33 +60,40 @@ class TestGLCCLoader:
 
     @pytest.fixture(autouse=True)
     def _check_data(self):
+        """Skip the GLCC tests cleanly if any lake CSV is missing."""
         _require_files(*[GLCC_DIR / f for f in self.LAKE_FILES])
 
     def test_returns_non_empty_dataframe(self):
+        """Returns a non-empty DataFrame for the shipped GLCC data."""
         df = DataLoader().glcc(str(GLCC_DIR))
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
 
     def test_index_is_datetime(self):
+        """The output index is a DatetimeIndex named 'date'."""
         df = DataLoader().glcc(str(GLCC_DIR))
         assert isinstance(df.index, pd.DatetimeIndex)
         assert df.index.name == "date"
 
     def test_has_one_obs_column_per_lake(self):
+        """Output contains the expected per-lake ``*_nbs_obs`` columns."""
         df = DataLoader().glcc(str(GLCC_DIR))
         assert self.EXPECTED_COLS.issubset(set(df.columns))
 
     def test_observed_columns_are_numeric(self):
+        """Every per-lake observed column has a numeric dtype."""
         df = DataLoader().glcc(str(GLCC_DIR))
         for col in self.EXPECTED_COLS:
             assert pd.api.types.is_numeric_dtype(df[col]), f"{col} not numeric"
 
     def test_dates_are_monthly_first_of_month(self):
+        """Every date falls on the first of the month."""
         df = DataLoader().glcc(str(GLCC_DIR))
         # All dates should be the first of the month — no stray mid-month rows.
         assert (df.index.day == 1).all()
 
     def test_dates_are_unique(self):
+        """The date index has no duplicates."""
         df = DataLoader().glcc(str(GLCC_DIR))
         assert df.index.is_unique, "duplicate dates in GLCC output"
 
@@ -97,6 +106,7 @@ class TestGLCCLoader:
         )
 
     def test_units_mm_changes_values(self):
+        """Requesting mm units yields different values than cms (unit conversion applied)."""
         df_cms = DataLoader().glcc(str(GLCC_DIR), units="cms")
         df_mm = DataLoader().glcc(str(GLCC_DIR), units="mm")
         # Same shape, but mm values are scaled by lake area + seconds-in-month.
@@ -123,26 +133,32 @@ class TestGLCCLoader:
 # l2swbm — Large Lake Statistical Water Balance Model, 12 CSVs
 # ===========================================================================
 class TestL2SWBMLoader:
+    """Tests the L2SWBM loader (``DataLoader.l2swbm``) against shipped CSVs."""
+
     LAKES = ["superior", "michigan-huron", "erie", "ontario"]
     VARS = ["Evap", "Runoff", "Precip"]
 
     @staticmethod
     def _filename(lake: str, var: str) -> str:
+        """Return the L2SWBM CSV filename for a given lake and variable."""
         token = "miHuron" if lake == "michigan-huron" else lake
         return f"{token}{var}_MonthlyRun.csv"
 
     @pytest.fixture(autouse=True)
     def _check_data(self):
+        """Skip the L2SWBM tests cleanly if any (lake, variable) CSV is missing."""
         files = [L2SWBM_DIR / self._filename(lake, var)
                  for lake in self.LAKES for var in self.VARS]
         _require_files(*files)
 
     def test_returns_non_empty_dataframe(self):
+        """Returns a non-empty DataFrame for the shipped L2SWBM data."""
         df = DataLoader().l2swbm(str(L2SWBM_DIR))
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
 
     def test_index_is_datetime(self):
+        """The output index is a DatetimeIndex named 'date'."""
         df = DataLoader().l2swbm(str(L2SWBM_DIR))
         assert isinstance(df.index, pd.DatetimeIndex)
         assert df.index.name == "date"
@@ -162,6 +178,7 @@ class TestL2SWBMLoader:
         assert not missing, f"missing required columns: {missing}"
 
     def test_all_value_columns_are_numeric(self):
+        """Every value column has a numeric dtype."""
         df = DataLoader().l2swbm(str(L2SWBM_DIR))
         for col in df.columns:
             assert pd.api.types.is_numeric_dtype(df[col]), f"{col} not numeric"
@@ -199,6 +216,7 @@ class TestL2SWBMLoader:
             assert (df[col] < 1000).all(), f"{col} has implausibly large positive values"
 
     def test_runoff_non_negative(self):
+        """Sanity: runoff values are never negative."""
         df = DataLoader().l2swbm(str(L2SWBM_DIR))
         for col in [c for c in df.columns if c.endswith("_runoff_obs")]:
             assert (df[col] >= 0).all(), f"{col} has negative values"
@@ -208,18 +226,23 @@ class TestL2SWBMLoader:
 # glsea — Surface temperature, single whitespace-separated CSV
 # ===========================================================================
 class TestGLSEALoader:
+    """Tests the GLSEA surface-temperature loader (``DataLoader.glsea``)."""
+
     EXPECTED_COLS = ["superior_sst", "michigan-huron_sst", "erie_sst", "ontario_sst"]
 
     @pytest.fixture(autouse=True)
     def _check_data(self):
+        """Skip the GLSEA tests cleanly if the SST CSV is missing."""
         _require_files(GLSEA_FILE)
 
     def test_returns_non_empty_dataframe(self):
+        """Returns a non-empty DataFrame for the shipped GLSEA data."""
         df = DataLoader().glsea(str(GLSEA_FILE))
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
 
     def test_index_is_datetime(self):
+        """The output index is a DatetimeIndex."""
         df = DataLoader().glsea(str(GLSEA_FILE))
         assert isinstance(df.index, pd.DatetimeIndex)
 
@@ -233,6 +256,7 @@ class TestGLSEALoader:
         assert list(df.columns) == self.EXPECTED_COLS
 
     def test_values_are_numeric(self):
+        """Every temperature column has a numeric dtype."""
         df = DataLoader().glsea(str(GLSEA_FILE))
         for col in df.columns:
             assert pd.api.types.is_numeric_dtype(df[col]), f"{col} not numeric"
@@ -249,6 +273,7 @@ class TestGLSEALoader:
         assert (non_nan < 310).all().all(), "GLSEA Kelvin values implausibly hot"
 
     def test_celsius_units_in_lake_temperature_range(self):
+        """With units='C', values fall in a plausible Celsius lake-temperature range."""
         df = DataLoader().glsea(str(GLSEA_FILE), units="C")
         non_nan = df.dropna()
         assert (non_nan > -5).all().all(), "GLSEA Celsius values implausibly cold"
@@ -268,6 +293,7 @@ class TestGLSEALoader:
         assert (mh >= all_min).all() and (mh <= all_max).all()
 
     def test_unsupported_units_raises(self):
+        """An unsupported units argument raises ValueError."""
         with pytest.raises(ValueError, match="Unsupported units"):
             DataLoader().glsea(str(GLSEA_FILE), units="F")
 
@@ -276,6 +302,8 @@ class TestGLSEALoader:
 # lake_probabilities — 4 lake CSVs of probability of exceedance × 12 months
 # ===========================================================================
 class TestLakeProbabilitiesLoader:
+    """Tests the lake-probabilities loader (``DataLoader.lake_probabilities``)."""
+
     LAKE_FILES = ["SUP.probs.csv", "MIH.probs.csv", "ERI.probs.csv", "ONT.probs.csv"]
     LAKES = ["superior", "michigan-huron", "erie", "ontario"]
     MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -283,28 +311,34 @@ class TestLakeProbabilitiesLoader:
 
     @pytest.fixture(autouse=True)
     def _check_data(self):
+        """Skip the probabilities tests cleanly if any lake CSV is missing."""
         _require_files(*[PROBABILITIES_DIR / f for f in self.LAKE_FILES])
 
     @pytest.fixture
     def probs_dir(self):
+        """Return the probabilities directory with a trailing separator for the loader."""
         # Loader uses string concat (file_dir + filename), so trailing sep needed.
         return str(PROBABILITIES_DIR) + "/"
 
     def test_returns_long_format(self, probs_dir):
+        """Returns a long-format DataFrame with the expected four columns."""
         df = DataLoader().lake_probabilities(probs_dir)
         assert list(df.columns) == ["month", "lake", "prob_exceedance", "value"]
 
     def test_has_all_four_lakes(self, probs_dir):
+        """Output covers all four lakes."""
         df = DataLoader().lake_probabilities(probs_dir)
         assert set(df["lake"].unique()) == set(self.LAKES)
 
     def test_has_all_twelve_months_per_lake(self, probs_dir):
+        """Each lake has all twelve months represented."""
         df = DataLoader().lake_probabilities(probs_dir)
         for lake in self.LAKES:
             months_for_lake = set(df[df["lake"] == lake]["month"])
             assert months_for_lake == set(self.MONTHS), f"{lake} missing months"
 
     def test_prob_exceedance_is_float(self, probs_dir):
+        """The prob_exceedance column has a float dtype."""
         df = DataLoader().lake_probabilities(probs_dir)
         assert pd.api.types.is_float_dtype(df["prob_exceedance"])
 
@@ -319,6 +353,7 @@ class TestLakeProbabilitiesLoader:
         assert (df["value"].abs() < 100000).all()
 
     def test_mm_units_changes_values(self, probs_dir):
+        """Requesting mm units yields different values than cms (unit conversion applied)."""
         df_cms = DataLoader().lake_probabilities(probs_dir, units="cms")
         df_mm = DataLoader().lake_probabilities(probs_dir, units="mm")
         assert df_cms.shape == df_mm.shape

--- a/tests/unit/test_data_processor_pipeline.py
+++ b/tests/unit/test_data_processor_pipeline.py
@@ -87,10 +87,12 @@ class TestProcessFilesValidation:
     """
 
     def _make_processor(self, monkeypatch):
+        """Build a CFSProcessor with its database constructor mocked out."""
         monkeypatch.setattr("src.data_processor.CFSDatabase", lambda *a, **k: MagicMock())
         return CFSProcessor(database="fake.db", table="cfs")
 
     def test_missing_download_dir_raises(self, tmp_path, monkeypatch):
+        """Raises ValueError when the download directory doesn't exist."""
         proc = self._make_processor(monkeypatch)
         with pytest.raises(ValueError, match="directory does not exist"):
             proc.process_files(
@@ -100,11 +102,13 @@ class TestProcessFilesValidation:
             )
 
     def test_missing_mask_file_raises(self, tmp_path, monkeypatch):
+        """Raises ValueError when the mask file doesn't exist."""
         proc = self._make_processor(monkeypatch)
         with pytest.raises(ValueError, match="mask_file not found"):
             proc.process_files(str(tmp_path), str(tmp_path / "missing.nc"), ["sup_lake"])
 
     def test_non_list_mask_variables_raises(self, tmp_path, monkeypatch):
+        """Raises ValueError when mask_variables is not a list."""
         proc = self._make_processor(monkeypatch)
         # Create a real file so the mask_file check passes
         mask_path = tmp_path / "mask.nc"
@@ -129,6 +133,7 @@ class TestPrecipitationMaskingMath:
     """
 
     def test_pgbf_january_writes_expected_row(self, tmp_path, monkeypatch):
+        """A January pgbf file writes one DB row with the expected metadata and pcp_mm value."""
         # --- fakes ---
         fake_mask_ds = _build_fake_mask_dataset()
         pcp_value = 0.001

--- a/tests/unit/test_forecast_smoke.py
+++ b/tests/unit/test_forecast_smoke.py
@@ -34,6 +34,7 @@ FIXTURE = REPO_ROOT / "tests" / "fixtures" / "forecasts" / "CNBS_forecast_wide.t
 
 
 def _load_fixture():
+    """Load the shipped forecast fixture TSV as a DataFrame with string id columns."""
     return pd.read_csv(FIXTURE, sep="\t", dtype={"cfs_run": str, "forecast_month": str})
 
 
@@ -58,13 +59,18 @@ def _toy_forecast():
 # Fixture loads cleanly and all checks pass on it
 # ===========================================================================
 class TestFixturePasses:
+    """The shipped fixture loads and passes the full smoke check."""
+
     def test_fixture_file_exists(self):
+        """The shipped forecast fixture file is present on disk."""
         assert FIXTURE.exists(), f"missing fixture: {FIXTURE}"
 
     def test_smoke_check_forecast_passes_on_fixture(self):
+        """smoke_check_forecast passes on the shipped fixture without raising."""
         smoke_check_forecast(_load_fixture())
 
     def test_smoke_check_forecast_passes_on_toy(self):
+        """smoke_check_forecast passes on a synthetic all-lakes forecast."""
         smoke_check_forecast(_toy_forecast())
 
 
@@ -72,41 +78,51 @@ class TestFixturePasses:
 # smoke_check_schema
 # ===========================================================================
 class TestSmokeCheckSchema:
+    """Schema validation: required columns, lake names, and id-column formats."""
+
     def test_passes_on_healthy_dataframe(self):
+        """Passes on the healthy fixture DataFrame."""
         smoke_check_schema(_load_fixture())
 
     def test_rejects_non_dataframe(self):
+        """Rejects input that isn't a pandas DataFrame."""
         with pytest.raises(ValueError, match="Expected pandas DataFrame"):
             smoke_check_schema({"not": "a df"})
 
     def test_rejects_empty_dataframe(self):
+        """Rejects an empty DataFrame even with the right columns."""
         empty = pd.DataFrame(columns=list(REQUIRED_COLUMNS))
         with pytest.raises(ValueError, match="empty"):
             smoke_check_schema(empty)
 
     def test_rejects_missing_component_column(self):
+        """Rejects a DataFrame missing a required component column."""
         df = _load_fixture().drop(columns=["nbs"])
         with pytest.raises(ValueError, match="missing required columns"):
             smoke_check_schema(df)
 
     def test_rejects_missing_id_column(self):
+        """Rejects a DataFrame missing a required id column."""
         df = _load_fixture().drop(columns=["forecast_month"])
         with pytest.raises(ValueError, match="missing required columns"):
             smoke_check_schema(df)
 
     def test_rejects_unexpected_lake_name(self):
+        """Rejects a lake name outside EXPECTED_LAKES."""
         df = _load_fixture()
         df.loc[0, "lake"] = "saint-clair"
         with pytest.raises(ValueError, match="unexpected lake names"):
             smoke_check_schema(df)
 
     def test_rejects_bad_cfs_run_format(self):
+        """Rejects a cfs_run that isn't a 10-digit string."""
         df = _load_fixture()
         df.loc[0, "cfs_run"] = "20240904"  # 8 digits, not 10
         with pytest.raises(ValueError, match="cfs_run"):
             smoke_check_schema(df)
 
     def test_rejects_bad_forecast_month_format(self):
+        """Rejects a forecast_month not in YYYY-MM format."""
         df = _load_fixture()
         df.loc[0, "forecast_month"] = "Sep 2024"
         with pytest.raises(ValueError, match="forecast_month"):
@@ -124,28 +140,35 @@ class TestSmokeCheckSchema:
 # smoke_check_no_nans
 # ===========================================================================
 class TestSmokeCheckNoNans:
+    """NaN/sentinel validation across component and id columns."""
+
     def test_passes_on_healthy_dataframe(self):
+        """Passes on the healthy fixture with no NaNs or sentinels."""
         smoke_check_no_nans(_load_fixture())
 
     def test_rejects_nan_in_component_column(self):
+        """Rejects a NaN in a component column."""
         df = _load_fixture()
         df.loc[0, "precipitation"] = np.nan
         with pytest.raises(ValueError, match="NaN values"):
             smoke_check_no_nans(df)
 
     def test_rejects_nan_in_id_column(self):
+        """Rejects a NaN in an id column."""
         df = _load_fixture()
         df.loc[0, "forecast_month"] = np.nan
         with pytest.raises(ValueError, match="NaN values"):
             smoke_check_no_nans(df)
 
     def test_rejects_glcc_sentinel_fill_value(self):
+        """Rejects the GLCC -99990 sentinel fill value."""
         df = _load_fixture()
         df.loc[0, "nbs"] = -99990.0
         with pytest.raises(ValueError, match="sentinel fill"):
             smoke_check_no_nans(df)
 
     def test_rejects_alt_sentinel_fill_value(self):
+        """Rejects the alternate -9999 sentinel fill value."""
         df = _load_fixture()
         df.loc[0, "evaporation"] = -9999.0
         with pytest.raises(ValueError, match="sentinel fill"):
@@ -156,7 +179,10 @@ class TestSmokeCheckNoNans:
 # smoke_check_ranges
 # ===========================================================================
 class TestSmokeCheckRanges:
+    """Physical-range validation for forecast component values."""
+
     def test_passes_on_healthy_dataframe(self):
+        """Passes on the healthy fixture with all values in range."""
         smoke_check_ranges(_load_fixture())
 
     def test_rejects_negative_precipitation(self):
@@ -167,6 +193,7 @@ class TestSmokeCheckRanges:
             smoke_check_ranges(df)
 
     def test_rejects_negative_runoff(self):
+        """Rejects negative runoff (below the lower bound)."""
         df = _load_fixture()
         df.loc[0, "runoff"] = -5.0
         with pytest.raises(ValueError, match="runoff.*below"):
@@ -193,12 +220,14 @@ class TestSmokeCheckRanges:
             smoke_check_ranges(df)
 
     def test_rejects_implausibly_large_negative_nbs(self):
+        """Rejects an implausibly large negative NBS (below the lower bound)."""
         df = _load_fixture()
         df.loc[0, "nbs"] = -2000.0
         with pytest.raises(ValueError, match="nbs.*below"):
             smoke_check_ranges(df)
 
     def test_rejects_implausibly_large_positive_nbs(self):
+        """Rejects an implausibly large positive NBS (above the upper bound)."""
         df = _load_fixture()
         df.loc[0, "nbs"] = 5000.0
         with pytest.raises(ValueError, match="nbs.*above"):
@@ -227,21 +256,27 @@ class TestSmokeCheckRanges:
 # smoke_check_forecast composes the others
 # ===========================================================================
 class TestSmokeCheckForecast:
+    """The composite smoke_check_forecast surfaces each sub-check's failure."""
+
     def test_passes_on_fixture(self):
+        """Passes on the healthy fixture."""
         smoke_check_forecast(_load_fixture())
 
     def test_fails_on_schema_break(self):
+        """Fails (schema error) when a required column is dropped."""
         df = _load_fixture().drop(columns=["nbs"])
         with pytest.raises(ValueError, match="missing required columns"):
             smoke_check_forecast(df)
 
     def test_fails_on_nan(self):
+        """Fails (NaN error) when a value is NaN."""
         df = _load_fixture()
         df.loc[0, "precipitation"] = np.nan
         with pytest.raises(ValueError, match="NaN"):
             smoke_check_forecast(df)
 
     def test_fails_on_range_break(self):
+        """Fails (range error) when a value is out of range."""
         df = _load_fixture()
         df.loc[0, "precipitation"] = -10.0
         with pytest.raises(ValueError, match="below"):
@@ -252,11 +287,15 @@ class TestSmokeCheckForecast:
 # Defaults are sane (regression guard against accidental edits to constants)
 # ===========================================================================
 class TestModuleConstants:
+    """Regression guards on the module-level constant definitions."""
+
     def test_expected_components_match_required_columns(self):
+        """Every expected component appears in REQUIRED_COLUMNS."""
         for component in EXPECTED_COMPONENTS:
             assert component in REQUIRED_COLUMNS
 
     def test_every_component_has_a_range(self):
+        """Every expected component has a non-inverted range in COMPONENT_RANGES_MM."""
         for component in EXPECTED_COMPONENTS:
             assert component in COMPONENT_RANGES_MM
             low, high = COMPONENT_RANGES_MM[component]
@@ -267,4 +306,5 @@ class TestModuleConstants:
         assert COMPONENT_RANGES_MM["precipitation"][0] >= 0
 
     def test_runoff_lower_bound_is_non_negative(self):
+        """Runoff's lower bound is non-negative."""
         assert COMPONENT_RANGES_MM["runoff"][0] >= 0

--- a/tests/unit/test_hydro_utils.py
+++ b/tests/unit/test_hydro_utils.py
@@ -22,20 +22,27 @@ from src.hydro_utils import (
 # seconds_in_month
 # ---------------------------------------------------------------------------
 class TestSecondsInMonth:
+    """Tests ``seconds_in_month`` day counts and month-range validation."""
+
     def test_january_has_31_days(self):
+        """January returns 31 days' worth of seconds."""
         assert seconds_in_month(2023, 1) == 31 * 86400
 
     def test_february_non_leap(self):
+        """February in a non-leap year returns 28 days' worth of seconds."""
         assert seconds_in_month(2023, 2) == 28 * 86400
 
     def test_february_leap(self):
+        """February in a leap year returns 29 days' worth of seconds."""
         assert seconds_in_month(2024, 2) == 29 * 86400
 
     def test_april_has_30_days(self):
+        """April returns 30 days' worth of seconds."""
         assert seconds_in_month(2023, 4) == 30 * 86400
 
     @pytest.mark.parametrize("bad_month", [0, 13, -1, 100])
     def test_invalid_month_raises(self, bad_month):
+        """A month outside 1-12 raises ValueError."""
         with pytest.raises(ValueError, match="Month must be between 1 and 12"):
             seconds_in_month(2023, bad_month)
 
@@ -44,13 +51,17 @@ class TestSecondsInMonth:
 # calculate_grid_cell_areas
 # ---------------------------------------------------------------------------
 class TestCalculateGridCellAreas:
+    """Tests grid-cell area computation by ``calculate_grid_cell_areas``."""
+
     def test_returns_2d_array_with_correct_shape(self):
+        """Returns a 2D (n_lat, n_lon) array."""
         lon = np.array([0.0, 1.0, 2.0])
         lat = np.array([10.0, 11.0])
         area = calculate_grid_cell_areas(lon, lat)
         assert area.shape == (2, 3)
 
     def test_areas_are_positive(self):
+        """All computed cell areas are positive."""
         lon = np.linspace(-90, -75, 5)
         lat = np.linspace(40, 50, 4)
         area = calculate_grid_cell_areas(lon, lat)
@@ -74,6 +85,7 @@ class TestCalculateGridCellAreas:
         assert area[0, 0] == pytest.approx(expected, rel=1e-12)
 
     def test_2d_input_raises(self):
+        """Raises ValueError when given 2D lon/lat arrays instead of 1D."""
         lon = np.zeros((2, 2))
         lat = np.zeros((2, 2))
         with pytest.raises(ValueError, match="must be 1D arrays"):
@@ -84,7 +96,10 @@ class TestCalculateGridCellAreas:
 # calculate_evaporation_rate
 # ---------------------------------------------------------------------------
 class TestCalculateEvaporation:
+    """Tests ``calculate_evaporation_rate`` formula, dtype handling, and monotonicity."""
+
     def test_scalar_inputs_return_scalar(self):
+        """Scalar inputs return the expected scalar evaporation rate."""
         result = calculate_evaporation_rate(temperature_K=288.15, latent_heat_flux=2_500_000.0)
         # latent_heat W/m² * 1e-6 / lambda(MJ/kg)  -> kg/(m²·s)
         # at 15°C: lambda = 2.501 - 0.002361*15 = 2.46557
@@ -92,6 +107,7 @@ class TestCalculateEvaporation:
         assert result == pytest.approx(expected, rel=1e-9)
 
     def test_array_inputs_return_array(self):
+        """Array inputs return a positive array of matching shape."""
         T = np.array([273.15, 288.15, 303.15])
         LE = np.array([1e6, 2e6, 3e6])
         result = calculate_evaporation_rate(T, LE)
@@ -100,9 +116,11 @@ class TestCalculateEvaporation:
         assert (result > 0).all()
 
     def test_zero_latent_heat_gives_zero_evaporation(self):
+        """Zero latent-heat flux yields zero evaporation."""
         assert calculate_evaporation_rate(288.15, 0.0) == 0.0
 
     def test_higher_latent_heat_means_more_evaporation(self):
+        """Higher latent-heat flux yields more evaporation at the same temperature."""
         low = calculate_evaporation_rate(288.15, 1e6)
         high = calculate_evaporation_rate(288.15, 2e6)
         assert high > low
@@ -112,7 +130,10 @@ class TestCalculateEvaporation:
 # convert_mm_to_cms
 # ---------------------------------------------------------------------------
 class TestConvertMmToCms:
+    """Tests mm-to-cms conversion (per-lake area + month length) by ``convert_mm_to_cms``."""
+
     def _toy_df(self):
+        """Build a four-lake toy DataFrame of 10 mm values for January 2023."""
         return pd.DataFrame(
             {
                 "value [mm]": [10.0, 10.0, 10.0, 10.0],
@@ -123,6 +144,7 @@ class TestConvertMmToCms:
         )
 
     def test_adds_cms_column(self):
+        """Adds a 'value [cms]' column to the output."""
         df = convert_mm_to_cms(self._toy_df())
         assert "value [cms]" in df.columns
 
@@ -136,6 +158,7 @@ class TestConvertMmToCms:
         assert sup_row == pytest.approx(expected, rel=1e-12)
 
     def test_michigan_huron_uses_combined_area(self):
+        """Michigan-Huron conversion uses the combined Michigan + Huron surface area."""
         df = convert_mm_to_cms(self._toy_df())
         combined_sa = (57753 + 59560) * 1_000_000
         secs = 31 * 86400
@@ -144,6 +167,7 @@ class TestConvertMmToCms:
         assert mh == pytest.approx(expected, rel=1e-12)
 
     def test_unknown_lake_yields_zero(self):
+        """An unrecognized lake name converts to a cms value of zero."""
         df = pd.DataFrame(
             {
                 "value [mm]": [10.0],

--- a/tests/unit/test_missing_files.py
+++ b/tests/unit/test_missing_files.py
@@ -25,6 +25,8 @@ from src.data_processor import SeasonalCycleProcessor
 # load_model — both error branches in its documented contract
 # ===========================================================================
 class TestLoadModel:
+    """Tests ``load_model`` error branches for unknown names and missing files."""
+
     def test_unknown_model_name_raises_value_error(self):
         """If model_name isn't in models_info, raise ValueError with a clear message."""
         models_info = [{"model": "GP", "path": "/tmp/gp.joblib"}]
@@ -42,7 +44,10 @@ class TestLoadModel:
 # SeasonalCycleProcessor.load — relies on pandas / open() to raise
 # ===========================================================================
 class TestSeasonalCycleProcessorLoad:
+    """Tests ``SeasonalCycleProcessor.load`` raises when its inputs are missing."""
+
     def test_missing_climatology_raises_file_not_found(self, tmp_path):
+        """A missing climatology CSV raises FileNotFoundError."""
         bad_path = str(tmp_path / "no_such_climatology.csv")
         meta_path = tmp_path / "meta.json"
         meta_path.write_text("{}")
@@ -50,6 +55,7 @@ class TestSeasonalCycleProcessorLoad:
             SeasonalCycleProcessor.load(bad_path, str(meta_path))
 
     def test_missing_metadata_raises_file_not_found(self, tmp_path):
+        """A missing metadata JSON raises FileNotFoundError even when climatology exists."""
         # Create a real (empty) climatology so the first read succeeds far enough.
         clim = tmp_path / "clim.csv"
         clim.write_text("month,var_a\n1,0.0\n")
@@ -69,18 +75,22 @@ class TestDataLoaderMissingFiles:
     """
 
     def test_glcc_missing_directory_raises(self, tmp_path):
+        """glcc raises FileNotFoundError when its directory doesn't exist."""
         with pytest.raises(FileNotFoundError):
             DataLoader().glcc(str(tmp_path / "no_such_dir"))
 
     def test_l2swbm_missing_directory_raises(self, tmp_path):
+        """l2swbm raises FileNotFoundError when its directory doesn't exist."""
         with pytest.raises(FileNotFoundError):
             DataLoader().l2swbm(str(tmp_path / "no_such_dir"))
 
     def test_glsea_missing_file_raises(self, tmp_path):
+        """glsea raises FileNotFoundError when its file doesn't exist."""
         with pytest.raises(FileNotFoundError):
             DataLoader().glsea(str(tmp_path / "no_such_file.csv"))
 
     def test_lake_probabilities_missing_directory_raises(self, tmp_path):
+        """lake_probabilities raises FileNotFoundError when its directory doesn't exist."""
         # Loader uses string concatenation; pass with trailing separator.
         with pytest.raises(FileNotFoundError):
             DataLoader().lake_probabilities(str(tmp_path / "no_such_dir") + "/")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -99,16 +99,19 @@ class TestCreateDirectoryAcceptsBothStrAndPath:
     """
 
     def test_str_input_creates_directory(self, tmp_path):
+        """Creates the directory when given a str path."""
         target = tmp_path / "from_str"
         create_directory(str(target))
         assert target.is_dir()
 
     def test_path_input_creates_directory(self, tmp_path):
+        """Creates the directory when given a pathlib.Path."""
         target = tmp_path / "from_path"
         create_directory(target)  # pathlib.Path, not str
         assert target.is_dir()
 
     def test_str_and_path_inputs_are_equivalent(self, tmp_path):
+        """str and Path inputs both create their directories equivalently."""
         a = tmp_path / "a"
         b = tmp_path / "b"
         create_directory(str(a))
@@ -125,13 +128,16 @@ class TestGetFilesAcceptsBothStrAndPath:
     """
 
     def _populate(self, d: Path):
+        """Create a couple of sample files in directory ``d``."""
         (d / "alpha.csv").write_text("x")
         (d / "beta.txt").write_text("x")
 
     def test_str_input_does_not_raise(self, tmp_path):
+        """get_files accepts a str directory without raising."""
         self._populate(tmp_path)
         get_files(str(tmp_path), affix="suffix", identifier=".csv")
 
     def test_path_input_does_not_raise(self, tmp_path):
+        """get_files accepts a pathlib.Path directory without raising."""
         self._populate(tmp_path)
         get_files(tmp_path, affix="suffix", identifier=".csv")

--- a/tests/unit/test_seasonal_cycle_processor.py
+++ b/tests/unit/test_seasonal_cycle_processor.py
@@ -1,4 +1,10 @@
 # tests/test_seasonal_cycle_processor.py
+"""
+Unit tests for ``SeasonalCycleProcessor`` in ``src/data_processor.py``.
+
+Uses a tiny synthetic monthly DataFrame to check the transform/inverse-transform
+roundtrip, monthly climatology anomaly indexing, and the fit/transform guardrails.
+"""
 
 import numpy as np
 import pandas as pd

--- a/tests/unit/test_transformers.py
+++ b/tests/unit/test_transformers.py
@@ -22,13 +22,17 @@ from src.data_processor import CFSTransformer, ForecastTransformer
 # Constructor validation (both transformers)
 # ===========================================================================
 class TestConstructorValidation:
+    """Both transformers reject non-DataFrame constructor inputs."""
+
     @pytest.mark.parametrize("bad_input", [None, 42, "not a df", [1, 2, 3]])
     def test_cfs_transformer_rejects_non_dataframe(self, bad_input):
+        """CFSTransformer raises ValueError when not given a DataFrame."""
         with pytest.raises(ValueError, match="must be a pandas DataFrame"):
             CFSTransformer(bad_input)
 
     @pytest.mark.parametrize("bad_input", [None, 42, "not a df", [1, 2, 3]])
     def test_forecast_transformer_rejects_non_dataframe(self, bad_input):
+        """ForecastTransformer raises ValueError when not given a DataFrame."""
         with pytest.raises(ValueError, match="must be a pandas DataFrame"):
             ForecastTransformer(bad_input)
 
@@ -44,9 +48,11 @@ class TestCFSTransformerFilter:
 
     @staticmethod
     def _build(cfs_runs):
+        """Build a DataFrame with the given cfs_run values and a running value column."""
         return pd.DataFrame({"cfs_run": cfs_runs, "value": range(len(cfs_runs))})
 
     def test_filters_out_runs_before_window(self):
+        """Drops cfs_runs older than first_forecast_month minus months_back."""
         df = self._build([
             "2024010100",  # before window — drop
             "2024020100",  # within — keep
@@ -62,6 +68,7 @@ class TestCFSTransformerFilter:
         assert "2024010100" not in result["cfs_run"].astype(str).values
 
     def test_default_months_back_is_10(self):
+        """The default months_back window keeps only runs within the look-back."""
         df = self._build(["2023060100", "2024030100", "2024120100"])
         # Default months_back=10, first_fc=2024-12 -> start = 2024-03-01.
         result = CFSTransformer(df).filter(datetime(2024, 12, 1))
@@ -80,6 +87,7 @@ class TestCFSTransformerShift:
     """
 
     def test_lag_zero_lead_zero_only_renames_columns(self):
+        """lag=0, lead=0 renames columns to _mo0 without adding or dropping rows."""
         df = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [10.0, 20.0, 30.0]})
         out = CFSTransformer(df).shift_variables(lag=0, lead=0)
         assert list(out.columns) == ["a_mo0", "b_mo0"]
@@ -95,6 +103,7 @@ class TestCFSTransformerShift:
         assert len(out) == 3
 
     def test_dropna_removes_rows_with_shift_induced_nan(self):
+        """Rows left NaN by lag/lead shifting are dropped from the output."""
         df = pd.DataFrame({"a": [1.0, 2.0, 3.0, 4.0, 5.0]})
         out = CFSTransformer(df).shift_variables(lag=3, lead=3)
         # Lags up to mo-2 and leads up to mo2 → first 2 and last 2 rows have NaN → dropped.
@@ -119,6 +128,7 @@ class TestCFSTransformerStructureInput:
     COMPONENTS = ["precipitation", "evaporation", "air_temperature"]
 
     def _build_long_input(self, cfs_run="2024010100"):
+        """Build a long-format input covering all lakes, surfaces, components, and 11 months."""
         cfs_dt = pd.to_datetime(cfs_run, format="%Y%m%d%H")
 
         rows = []
@@ -143,12 +153,14 @@ class TestCFSTransformerStructureInput:
     # -----------------------------
 
     def test_returns_dataframe_with_expected_total_columns(self):
+        """Produces 240 feature columns (4 lakes × 2 surfaces × 3 components × 10 months)."""
         df = self._build_long_input()
         result = CFSTransformer(df).structure_input()
 
         assert result.shape[1] == 240 # 4 lakes × 2 surfaces × 3 components × 10 months
 
     def test_feature_columns_in_nested_lake_surface_component_month_order(self):
+        """Feature columns follow the nested lake/surface/component/month order."""
         df = self._build_long_input()
         result = CFSTransformer(df).structure_input()
 
@@ -165,12 +177,14 @@ class TestCFSTransformerStructureInput:
         assert feature_cols == expected
 
     def test_no_mo10_columns_in_output(self):
+        """The 11th forecast month (mo10) is excluded from the output columns."""
         df = self._build_long_input()
         result = CFSTransformer(df).structure_input()
 
         assert not any(c.endswith("_mo10") for c in result.columns)
 
     def test_accepts_value_mm_column_alias(self):
+        """Accepts a 'value [mm]' column as an alias for 'value'."""
         df = self._build_long_input().rename(columns={"value": "value [mm]"})
         result = CFSTransformer(df).structure_input()
 
@@ -182,8 +196,10 @@ import pytest
 
 
 class TestAddTimeFeatures:
+    """Tests ``CFSTransformer.add_time_features`` cycle/trend columns and overwrite."""
 
     def _build_df(self):
+        """Build a 4-month DataFrame with a monthly DatetimeIndex."""
         idx = pd.date_range("2024-01-01", periods=4, freq="MS")
         return pd.DataFrame({"value": [1, 2, 3, 4]}, index=idx)
 
@@ -191,6 +207,7 @@ class TestAddTimeFeatures:
     # Raises error if index is not DatetimeIndex
     # ---------------------------------------------------------
     def test_requires_datetime_index(self):
+        """Raises TypeError when the index is not a DatetimeIndex."""
         df = pd.DataFrame({"value": [1, 2, 3]})
 
         with pytest.raises(TypeError, match="DatetimeIndex"):
@@ -200,6 +217,7 @@ class TestAddTimeFeatures:
     # Adds month_sin and month_cos correctly
     # ---------------------------------------------------------
     def test_month_cycle_features(self):
+        """Adds month_sin and month_cos matching the sinusoidal month encoding."""
         df = self._build_df()
 
         result = CFSTransformer(df).add_time_features(
@@ -220,6 +238,7 @@ class TestAddTimeFeatures:
     # Time normalization centers data
     # ---------------------------------------------------------
     def test_time_trend_normalized(self):
+        """Normalized time trend has zero mean and unit standard deviation."""
         df = self._build_df()
 
         result = CFSTransformer(df).add_time_features(
@@ -239,6 +258,7 @@ class TestAddTimeFeatures:
     # Overwrite removes old columns
     # ---------------------------------------------------------
     def test_overwrite_behavior(self):
+        """overwrite=True replaces a pre-existing month_sin column."""
         df = self._build_df()
         df["month_sin"] = 999  # fake old value
 
@@ -258,6 +278,7 @@ class TestForecastTransformerMelt:
     """
 
     def _build_wide_input(self):
+        """Build a single-row wide input with precipitation and evaporation across months."""
         return pd.DataFrame([{
             "cfs_run": "2024010100",
             "model": "GP",
@@ -270,6 +291,7 @@ class TestForecastTransformerMelt:
         }])
 
     def test_id_vars_come_first(self):
+        """The id vars (cfs_run, model, lake, component) are the leading columns."""
         df = self._build_wide_input()
         out = ForecastTransformer(df).melt()
         assert list(out.columns[:4]) == ["cfs_run", "model", "lake", "component"]
@@ -314,6 +336,7 @@ class TestForecastTransformerPivot:
     """
 
     def _build_input(self):
+        """Build a single-row wide input with two months of precipitation and evaporation."""
         return pd.DataFrame([{
             "cfs_run": "2024010100",
             "model": "GP",
@@ -324,6 +347,7 @@ class TestForecastTransformerPivot:
         }])
 
     def test_id_columns_come_first_then_variables(self):
+        """The id columns (cfs_run, forecast_month, model, lake) lead, then variables follow."""
         df = self._build_input()
         out = ForecastTransformer(df).pivot()
         assert list(out.columns[:4]) == ["cfs_run", "forecast_month", "model", "lake"]
@@ -340,6 +364,7 @@ class TestForecastTransformerPivot:
         assert var_cols == ["precipitation", "evaporation"]
 
     def test_cfs_run_string_format_preserved(self):
+        """cfs_run round-trips back to its original %Y%m%d%H string."""
         df = self._build_input()
         out = ForecastTransformer(df).pivot()
         # cfs_run is round-tripped to "%Y%m%d%H" string.

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -26,17 +26,22 @@ from src.utilities import (
 # check_url_exists  (mocked — does not hit the network)
 # ---------------------------------------------------------------------------
 class TestCheckUrlExists:
+    """Tests for ``check_url_exists`` with the HTTP HEAD call mocked."""
+
     def test_returns_true_on_200(self):
+        """Returns True when the HEAD request responds with status 200."""
         fake_response = MagicMock(status_code=200)
         with patch("src.utilities.requests.head", return_value=fake_response):
             assert check_url_exists("https://example.com") is True
 
     def test_returns_false_on_non_200(self):
+        """Returns False when the HEAD request responds with a non-200 status."""
         fake_response = MagicMock(status_code=404)
         with patch("src.utilities.requests.head", return_value=fake_response):
             assert check_url_exists("https://example.com/missing") is False
 
     def test_returns_false_on_request_exception(self):
+        """Returns False when the HEAD request raises a RequestException."""
         with patch(
             "src.utilities.requests.head",
             side_effect=requests.ConnectionError("boom"),
@@ -48,28 +53,36 @@ class TestCheckUrlExists:
 # get_first_forecast_month
 # ---------------------------------------------------------------------------
 class TestGetFirstForecastMonth:
+    """Tests the 26th-of-month cutoff rule in ``get_first_forecast_month``."""
+
     def test_before_26th_returns_current_month(self):
+        """Before the 26th, returns the current month."""
         result = get_first_forecast_month(today=datetime(2024, 6, 10))
         assert result == "06-2024"
 
     def test_on_25th_still_current_month(self):
+        """On the 25th (boundary), still returns the current month."""
         # Boundary: rule says "before 26th" -> current month
         result = get_first_forecast_month(today=datetime(2024, 6, 25))
         assert result == "06-2024"
 
     def test_on_26th_rolls_to_next_month(self):
+        """On the 26th (boundary), rolls over to the next month."""
         result = get_first_forecast_month(today=datetime(2024, 6, 26))
         assert result == "07-2024"
 
     def test_after_26th_rolls_to_next_month(self):
+        """After the 26th, rolls over to the next month."""
         result = get_first_forecast_month(today=datetime(2024, 6, 30))
         assert result == "07-2024"
 
     def test_december_rollover_to_next_year(self):
+        """A late-December date rolls over to January of the next year."""
         result = get_first_forecast_month(today=datetime(2024, 12, 27))
         assert result == "01-2025"
 
     def test_default_today_runs_without_error(self):
+        """Calling with the default (real) today returns a well-formed MM-YYYY string."""
         # No assertion on value (date-dependent), just that the default path works.
         result = get_first_forecast_month()
         assert isinstance(result, str)
@@ -80,7 +93,10 @@ class TestGetFirstForecastMonth:
 # get_date_range
 # ---------------------------------------------------------------------------
 class TestGetDateRange:
+    """Tests manual and auto date-range resolution in ``get_date_range``."""
+
     def test_manual_valid_range_returns_datetimes_and_index(self):
+        """A valid manual range returns parsed start/end datetimes and an inclusive daily index."""
         start, end, idx = get_date_range(
             auto="no", start_date="01-01-2024", end_date="01-05-2024"
         )
@@ -89,6 +105,7 @@ class TestGetDateRange:
         assert len(idx) == 5  # daily, inclusive
 
     def test_manual_same_start_and_end_does_not_raise(self):
+        """Equal start and end dates yield a single-day index without raising."""
         # The function prints "up-to-date" but should not raise.
         start, end, idx = get_date_range(
             auto="no", start_date="01-01-2024", end_date="01-01-2024"
@@ -97,10 +114,12 @@ class TestGetDateRange:
         assert len(idx) == 1
 
     def test_manual_end_before_start_raises(self):
+        """An end date earlier than the start date raises ValueError."""
         with pytest.raises(ValueError, match="End date cannot be older"):
             get_date_range(auto="no", start_date="01-05-2024", end_date="01-01-2024")
 
     def test_auto_yes_without_db_raises(self):
+        """auto='yes' without a database object raises ValueError."""
         with pytest.raises(ValueError, match="Database object must be provided"):
             get_date_range(auto="yes", db=None)
 
@@ -122,13 +141,17 @@ class TestGetDateRange:
 # create_directory
 # ---------------------------------------------------------------------------
 class TestCreateDirectory:
+    """Tests directory creation behavior of ``create_directory``."""
+
     def test_creates_missing_directory(self, tmp_path):
+        """Creates a directory that does not yet exist."""
         target = tmp_path / "new_subdir"
         assert not target.exists()
         create_directory(str(target))
         assert target.is_dir()
 
     def test_no_error_when_directory_exists(self, tmp_path):
+        """Does not raise when the target directory already exists."""
         target = tmp_path / "existing"
         target.mkdir()
         # Should print and return without raising
@@ -136,6 +159,7 @@ class TestCreateDirectory:
         assert target.is_dir()
 
     def test_creates_nested_directory(self, tmp_path):
+        """Creates intermediate parent directories for a nested path."""
         target = tmp_path / "a" / "b" / "c"
         create_directory(str(target))
         assert target.is_dir()
@@ -145,7 +169,10 @@ class TestCreateDirectory:
 # get_files
 # ---------------------------------------------------------------------------
 class TestGetFiles:
+    """Tests suffix/prefix filtering of directory listings by ``get_files``."""
+
     def _populate(self, tmp_path):
+        """Create a fixed set of mixed-extension files in ``tmp_path``."""
         (tmp_path / "alpha.csv").write_text("x")
         (tmp_path / "beta.csv").write_text("x")
         (tmp_path / "alpha.txt").write_text("x")
@@ -153,6 +180,7 @@ class TestGetFiles:
         return tmp_path
 
     def test_suffix_match_returns_csv_files(self, tmp_path):
+        """Suffix match on '.csv' returns only the .csv files."""
         d = self._populate(tmp_path)
         result = get_files(str(d), affix="suffix", identifier=".csv")
         expected = [
@@ -162,6 +190,7 @@ class TestGetFiles:
         assert sorted(result) == sorted(expected)
 
     def test_prefix_match_returns_alpha_files(self, tmp_path):
+        """Prefix match on 'alpha' returns only files whose name starts with alpha."""
         d = self._populate(tmp_path)
         result = get_files(str(d), affix="prefix", identifier="alpha")
         expected = [
@@ -171,6 +200,7 @@ class TestGetFiles:
         assert sorted(result) == sorted(expected)
 
     def test_no_match_returns_empty_list(self, tmp_path):
+        """An identifier matching no files returns an empty list."""
         d = self._populate(tmp_path)
         result = get_files(str(d), affix="suffix", identifier=".nope")
         assert result == []


### PR DESCRIPTION
## Description
Documentation-only pass — no behavioral changes to the library.

Sphinx site:
- Add forecast_smoke API reference page and wire it into the toctree
- Add cartopy to autodoc_mock_imports so plotting imports under the
  pip-only docs build
- Set conf.py release to 1.2.0 (was 0.1) to match the README badge

Docstrings:
- Add module docstrings to all src/ modules and src/__init__.py
- Fill missing class/method docstrings (SSTDownloader, DataLoader,
  CFSDatabase, CFSProcessor, CFSTransformer, CNBSForecaster, plotting)
- Add module/class/method docstrings across the tests/ suite
- Fix RST formatting in existing NumPy-style docstrings (blank lines
  before lists, Google->NumPy in add_df) to clear build warnings

Consistency:
- Clarify forecast horizon in README (~9-month CFS input -> 12-month
  forecast)

## Related Issue
This PR fixes issue https://github.com/great-lakes-ai-lab/cnbs-predictor/issues/106.


