### PR TITLE
Speed up CNBS forecast loading

### DIFF
--- a/benchmarks/bench_database_load.py
+++ b/benchmarks/bench_database_load.py
@@ -1,0 +1,243 @@
+"""Benchmark and verify the CNBS database loading path.
+
+Reproduces the measurements behind the SQL-filtering change for notebook 3
+(Visuals), which was slow for USACE users reading ``cnbs_forecast.db`` from a
+shared network drive.
+
+It builds a synthetic, ensemble-shaped forecast table in a temporary directory,
+then compares three paths:
+
+1. **legacy** — ``load()`` then a per-row ``pd.Period`` filter (the original
+   implementation, reproduced here for reference).
+2. **vectorized** — ``load()`` then the current vectorized filter.
+3. **pushdown** — ``load(start_date=...)``, filtering in SQL.
+
+Alongside the timings it asserts the three paths return *identical* rows, and
+prints the SQLite query plan so you can see whether the filtered query uses the
+date index or still scans the table.
+
+For actual page-read counts — the closest proxy for bytes pulled over a network
+share — use the ``sqlite3`` CLI, which exposes the counters the Python module
+does not::
+
+    sqlite3 <db> ".stats on" "SELECT * FROM cnbs_forecast WHERE year >= 2027;"
+
+Run it directly; nothing is written outside a temporary directory::
+
+    conda activate nbs_env_test
+    python benchmarks/bench_database_load.py            # ~2M rows, a few minutes
+    python benchmarks/bench_database_load.py --small    # ~200k rows, quick
+
+Note on interpreting the results: the ``WHERE`` clause only reduces bytes read
+if the date columns are indexed. Without the index SQLite scans every page and
+reads just as much as an unfiltered query — which is why
+``CFSDatabase.add_df`` now indexes after each write.
+"""
+
+import argparse
+import os
+import shutil
+import sqlite3
+import sys
+import tempfile
+import time
+
+import pandas as pd
+
+# Make src/ importable when run from the repo root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.data_processor import ForecastTransformer  # noqa: E402
+from src.database_utils import CFSDatabase  # noqa: E402
+
+TABLE = "cnbs_forecast"
+START_DATE = "07-2026"
+
+LAKES = ["superior", "michigan-huron", "erie", "ontario"]
+COMPONENTS = ["precipitation", "evaporation", "runoff", "nbs"]
+MODELS = ["RF", "GP", "XGB", "MLR", "SVR"]
+
+
+def legacy_filter(df, first_forecast_month):
+    """
+    The original ``ForecastTransformer.filter`` year/month branch.
+
+    Kept here verbatim so the benchmark can show what the change replaced. It
+    builds one :class:`pandas.Period` per row via ``df.apply``, which is what
+    made notebook 3 slow.
+    """
+    df = df.copy()
+    min_period = pd.Period(first_forecast_month, freq="M")
+    df["forecast_period"] = df.apply(
+        lambda r: pd.Period(f"{r.year}-{r.month:02d}", freq="M"), axis=1
+    )
+    first_month_to_keep = max(df["forecast_period"].min(), min_period)
+    df = df[df["forecast_period"] >= first_month_to_keep]
+    return df.drop(columns=["forecast_period"])
+
+
+def build_table(database, months_of_runs=18, leads=12):
+    """
+    Write a synthetic forecast table shaped like the operational one.
+
+    Every forecast month carries a full ensemble — one row per
+    (cfs_run, model, lake, component) — so ``(year, month)`` is heavily
+    non-unique, as in the real database.
+
+    Parameters
+    ----------
+    database : str
+        Path of the SQLite file to create.
+    months_of_runs : int, default 18
+        How many months of 6-hourly CFS runs to generate.
+    leads : int, default 12
+        Forecast months per run.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The frame that was written.
+    """
+    end = pd.Timestamp("2026-06-30")
+    start = end - pd.DateOffset(months=months_of_runs)
+    runs = pd.date_range(start, end, freq="6h")
+
+    rows = []
+    for run in runs:
+        run_id = run.strftime("%Y%m%d%H")
+        for lead in range(leads):
+            valid = run + pd.DateOffset(months=lead)
+            for model in MODELS:
+                for lake in LAKES:
+                    for component in COMPONENTS:
+                        rows.append((
+                            run_id, valid.month, valid.year,
+                            model, lake, component, 1.0, 2.0,
+                        ))
+
+    df = pd.DataFrame(rows, columns=[
+        "cfs_run", "month", "year", "model", "lake", "component",
+        "value [mm]", "value [cms]",
+    ])
+
+    # add_df indexes the date columns as part of the write.
+    CFSDatabase(database, TABLE).add_df(df)
+    return df
+
+
+def time_it(fn):
+    """Run ``fn`` and return ``(result, elapsed_seconds)``."""
+    t0 = time.perf_counter()
+    result = fn()
+    return result, time.perf_counter() - t0
+
+
+def query_plan(database, sql):
+    """Return the EXPLAIN QUERY PLAN description lines for ``sql``."""
+    conn = sqlite3.connect(database)
+    try:
+        conn.execute("ANALYZE")
+        return [row[3] for row in conn.execute(f"EXPLAIN QUERY PLAN {sql}")]
+    finally:
+        conn.close()
+
+
+def index_names(database):
+    """Return user-defined index names in the database."""
+    conn = sqlite3.connect(database)
+    try:
+        return [
+            row[0] for row in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+            )
+        ]
+    finally:
+        conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--small", action="store_true",
+        help="Use a ~200k-row table instead of ~2M for a quick run.",
+    )
+    args = parser.parse_args()
+
+    months = 2 if args.small else 18
+    workdir = tempfile.mkdtemp(prefix="cnbs_bench_")
+    database = os.path.join(workdir, "cnbs_forecast.db")
+
+    try:
+        print("Building synthetic forecast table...")
+        df, build_s = time_it(lambda: build_table(database, months_of_runs=months))
+        size_mb = os.path.getsize(database) / 1e6
+        print(f"  rows      : {len(df):,}")
+        print(f"  file size : {size_mb:.1f} MB  (includes the date index)")
+        print(f"  build time: {build_s:.1f}s")
+        print(f"  indexes   : {', '.join(index_names(database)) or 'none'}")
+
+        db = CFSDatabase(database, TABLE)
+
+        print(f"\nFiltering from {START_DATE}...\n")
+
+        full, t_load = time_it(db.load)
+        legacy, t_legacy = time_it(lambda: legacy_filter(full, START_DATE))
+        vector, t_vector = time_it(
+            lambda: ForecastTransformer(full).filter(START_DATE)
+        )
+        pushed, t_push = time_it(lambda: db.load(start_date=START_DATE))
+        pushed_f, t_push_f = time_it(
+            lambda: ForecastTransformer(pushed).filter(START_DATE)
+        )
+
+        print(f"{'path':<34}{'load':>9}{'filter':>10}{'total':>10}")
+        print("-" * 63)
+        print(f"{'legacy (per-row Period)':<34}{t_load:8.2f}s{t_legacy:9.2f}s"
+              f"{t_load + t_legacy:9.2f}s")
+        print(f"{'vectorized filter only':<34}{t_load:8.2f}s{t_vector:9.2f}s"
+              f"{t_load + t_vector:9.2f}s")
+        print(f"{'pushdown + vectorized':<34}{t_push:8.2f}s{t_push_f:9.2f}s"
+              f"{t_push + t_push_f:9.2f}s")
+
+        before = t_load + t_legacy
+        after = t_push + t_push_f
+        print(f"\nend-to-end speedup: {before / after:.0f}x "
+              f"({before:.1f}s -> {after:.1f}s)")
+
+        # --- correctness: all three paths must agree ---
+        key = ["cfs_run", "year", "month", "model", "lake", "component"]
+
+        def norm(frame):
+            return frame.sort_values(key).reset_index(drop=True)
+
+        legacy_n, vector_n, pushed_n = norm(legacy), norm(vector), norm(pushed_f)
+        print(f"\nrows kept: {len(pushed_n):,} of {len(df):,}")
+        print(f"  legacy == vectorized : {legacy_n.equals(vector_n)}")
+        print(f"  legacy == pushdown   : {legacy_n.equals(pushed_n)}")
+        assert legacy_n.equals(vector_n), "vectorized filter changed the result"
+        assert legacy_n.equals(pushed_n), "SQL pushdown changed the result"
+
+        # Ensembles: whole months are selected, members are never collapsed.
+        members = pushed_n.groupby(["year", "month"]).size().unique()
+        print(f"  ensemble members per kept month: {sorted(members)}")
+
+        # --- I/O: does the filtered query use the index? ---
+        filtered_sql = (
+            f"SELECT * FROM {TABLE} "
+            "WHERE year > 2026 OR (year = 2026 AND month >= 7)"
+        )
+        print("\nquery plan (filtered):")
+        for line in query_plan(database, filtered_sql):
+            print(f"  {line}")
+        print("\nA plan containing 'USING INDEX' is what reduces bytes read over")
+        print("a network share. 'SCAN' means the full table is being read --")
+        print("expected on small or unselective tables, where SQLite correctly")
+        print("judges a scan cheaper than an index lookup.")
+
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/production/3_LEF_visualization.ipynb
+++ b/notebooks/production/3_LEF_visualization.ipynb
@@ -193,7 +193,7 @@
     "This step loads the CNBS forecast output from the forecast database and filters the data to include only valid forecast months.\n",
     "\n",
     "- **Load forecast data**  \n",
-    "  The `CFSDatabase` class reads the CNBS forecast results from the SQLite database (`cnbs_forecast.db`) and loads them into a dataframe.\n",
+    "  The `CFSDatabase` class reads the CNBS forecast results from the SQLite database (`cnbs_forecast.db`) and loads them into a dataframe. Passing `start_date` filters the records in SQL, so only the forecast months actually needed are read from the database instead of the whole table. This matters most when the database is on a shared network drive, where transferring the full table dominates the runtime.\n",
     "\n",
     "- **Filter forecast months**  \n",
     "  The `ForecastTransformer.filter()` function removes any forecast records that occur before the defined `start_date` (forecast month 0). This ensures that only current and future forecast periods are retained.\n",
@@ -208,8 +208,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load CNBS predictions\n",
-    "data = CFSDatabase(cnbs_database, cnbs_table).load()\n",
+    "# Load CNBS predictions, filtering in SQL so only the needed months are read\n",
+    "data = CFSDatabase(cnbs_database, cnbs_table).load(start_date=start_date)\n",
     "df_filtered = ForecastTransformer(data).filter(start_date)"
    ]
   },

--- a/notebooks/production/python_scripts/3_LEF_visualization.py
+++ b/notebooks/production/python_scripts/3_LEF_visualization.py
@@ -112,7 +112,7 @@ start_date = get_first_forecast_month()
 # This step loads the CNBS forecast output from the forecast database and filters the data to include only valid forecast months.
 # 
 # - **Load forecast data**  
-#   The `CFSDatabase` class reads the CNBS forecast results from the SQLite database (`cnbs_forecast.db`) and loads them into a dataframe.
+#   The `CFSDatabase` class reads the CNBS forecast results from the SQLite database (`cnbs_forecast.db`) and loads them into a dataframe. Passing `start_date` filters the records in SQL, so only the forecast months actually needed are read from the database instead of the whole table. This matters most when the database is on a shared network drive, where transferring the full table dominates the runtime.
 # 
 # - **Filter forecast months**  
 #   The `ForecastTransformer.filter()` function removes any forecast records that occur before the defined `start_date` (forecast month 0). This ensures that only current and future forecast periods are retained.
@@ -120,8 +120,8 @@ start_date = get_first_forecast_month()
 # The resulting dataframe, `df_filtered`, contains the cleaned forecast data used for subsequent analysis, visualization, and Probability of Exceedance calculations.
 
 # %%
-# Load CNBS predictions
-data = CFSDatabase(cnbs_database, cnbs_table).load()
+# Load CNBS predictions, filtering in SQL so only the needed months are read
+data = CFSDatabase(cnbs_database, cnbs_table).load(start_date=start_date)
 df_filtered = ForecastTransformer(data).filter(start_date)
 
 # %% [markdown]

--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -1546,16 +1546,18 @@ class ForecastTransformer:
             return df
 
         elif "year" in df.columns and "month" in df.columns:
-            # Build Period
-            df["forecast_period"] = df.apply(lambda r: pd.Period(f"{r.year}-{r.month:02d}", freq="M"), axis=1)
+            # Compare months as integer ordinals (months since year 0) rather
+            # than building one Period object per row. Equivalent ordering,
+            # but vectorized — the per-row version dominated notebook 3's
+            # runtime on multi-million-row forecast tables.
+            month_ordinal = df["year"].astype(int) * 12 + df["month"].astype(int) - 1
+            min_ordinal = min_period.year * 12 + min_period.month - 1
 
-            first_month_in_data = df["forecast_period"].min()
-            first_month_to_keep = max(first_month_in_data, min_period)
+            first_month_in_data = month_ordinal.min()
+            first_month_to_keep = max(first_month_in_data, min_ordinal)
 
-            df = df[df["forecast_period"] >= first_month_to_keep]
+            df = df[month_ordinal >= first_month_to_keep]
 
-            # Optionally drop helper column
-            df = df.drop(columns=["forecast_period"])
             return df
 
         else:

--- a/src/database_utils.py
+++ b/src/database_utils.py
@@ -68,28 +68,149 @@ class CFSDatabase:
                 )
             ''')
 
-    def load(self):
+    def _date_columns(self, conn):
         """
-        Load the entire table into a DataFrame.
+        Report which forecast-date columns the table actually has.
+
+        The two writers in notebook 2 produce different layouts: the pivoted
+        frame carries a single ``forecast_month`` ('YYYY-MM') column, while the
+        unit-converted frame carries separate integer ``year`` and ``month``
+        columns. Callers sniff the layout the same way :meth:`pull` and
+        :meth:`add` sniff ``value`` vs ``value [mm]``.
+
+        Parameters
+        ----------
+        conn : sqlite3.Connection
+            Open connection to the database.
+
+        Returns
+        -------
+        tuple of bool
+            ``(has_year_month, has_forecast_month)``.
+        """
+        columns = {row[1] for row in conn.execute(f'PRAGMA table_info({self.table})')}
+        return {"year", "month"} <= columns, "forecast_month" in columns
+
+    def load(self, start_date=None):
+        """
+        Load the table into a DataFrame, optionally filtering in SQL.
+
+        Passing ``start_date`` pushes the forecast-month filter down into the
+        query so only the needed rows are read. This matters when the database
+        lives on a network share: filtering in pandas after a bare
+        ``SELECT *`` transfers the whole table first.
+
+        The filter is only usable if the table's date columns are indexed —
+        without an index SQLite scans every page regardless of the WHERE
+        clause, and reads no less data. :meth:`create_indexes` (run
+        automatically by :meth:`add_df`) provides that index.
+
+        Parameters
+        ----------
+        start_date : str, optional
+            Earliest forecast month to return, as anything
+            :class:`pandas.Period` accepts at monthly resolution — including
+            the 'MM-YYYY' returned by
+            :func:`src.utilities.get_first_forecast_month` and 'YYYY-MM'. If
+            None (default), the entire table is returned.
 
         Returns
         -------
         pandas.DataFrame
-            All rows of the configured table.
+            All rows of the configured table, or only those on/after
+            ``start_date``.
+
+        Raises
+        ------
+        ValueError
+            If ``start_date`` is given but the table has neither a
+            ``forecast_month`` column nor both ``year`` and ``month``.
         """
         # Create a connection to the SQLite database
         conn = sqlite3.connect(self.database)
 
-        # Use an f-string to insert the table name properly
-        query = f'SELECT * FROM {self.table}'
+        try:
+            # Use an f-string to insert the table name properly
+            query = f'SELECT * FROM {self.table}'
+            params = None
 
-        # Execute the query and fetch the data into a DataFrame
-        data = pd.read_sql(query, conn)
+            if start_date is not None:
+                # Accepts 'MM-YYYY', 'YYYY-MM', 'YYYY-MM-DD', ...
+                period = pd.Period(start_date, freq="M")
+                has_year_month, has_forecast_month = self._date_columns(conn)
 
-        # Close the connection once done
-        conn.close()
+                if has_year_month:
+                    # Written as two integer columns. Compared as
+                    # (year, month) pairs rather than an arithmetic
+                    # expression, because an expression over columns cannot
+                    # use the index and would force a full scan.
+                    query += ' WHERE year > ? OR (year = ? AND month >= ?)'
+                    params = (period.year, period.year, period.month)
+                elif has_forecast_month:
+                    # Written zero-padded via strftime('%Y-%m'), so a string
+                    # comparison orders months correctly.
+                    query += ' WHERE forecast_month >= ?'
+                    params = (str(period),)
+                else:
+                    raise ValueError(
+                        f"Cannot filter table '{self.table}' by start_date: it "
+                        "must contain either 'forecast_month' or "
+                        "('year','month') columns."
+                    )
+
+            # Execute the query and fetch the data into a DataFrame
+            data = pd.read_sql(query, conn, params=params)
+
+        finally:
+            # Close the connection once done
+            conn.close()
 
         return data
+
+    def create_indexes(self):
+        """
+        Index the table's forecast-date columns, if it has any.
+
+        Creating the index is what makes ``load(start_date=...)`` read less
+        data: with no index SQLite scans the full table even when a WHERE
+        clause is present, so a filtered query pulls just as many bytes over a
+        network share as an unfiltered one.
+
+        Safe to call repeatedly — it uses ``CREATE INDEX IF NOT EXISTS`` and
+        skips whichever columns the table does not have. :meth:`add_df` calls
+        it after every write, which also restores the index after an
+        ``if_exists='replace'`` write drops the table along with its indexes.
+
+        Returns
+        -------
+        list of str
+            Names of the indexes that now exist for this table.
+        """
+        created = []
+
+        conn = sqlite3.connect(self.database)
+        try:
+            has_year_month, has_forecast_month = self._date_columns(conn)
+
+            if has_year_month:
+                name = f'idx_{self.table}_year_month'
+                conn.execute(
+                    f'CREATE INDEX IF NOT EXISTS {name} ON {self.table} (year, month)'
+                )
+                created.append(name)
+
+            if has_forecast_month:
+                name = f'idx_{self.table}_forecast_month'
+                conn.execute(
+                    f'CREATE INDEX IF NOT EXISTS {name} ON {self.table} (forecast_month)'
+                )
+                created.append(name)
+
+            conn.commit()
+        finally:
+            conn.close()
+
+        return created
 
     def pull(self, cfs_run, year, month, lake, surface_type, component):
         """
@@ -246,6 +367,14 @@ class CFSDatabase:
             DataFrame to insert.
         if_exists : {"append", "replace", "fail"}, default "append"
             Behavior if the table already exists.
+
+        Notes
+        -----
+        Indexes the forecast-date columns afterwards via
+        :meth:`create_indexes`, so readers get the benefit of
+        ``load(start_date=...)`` without having to index the database
+        themselves. If indexing fails the write is still kept and a warning is
+        printed, since the index only affects speed and not correctness.
         """
 
         try:
@@ -279,6 +408,23 @@ class CFSDatabase:
         except sqlite3.DatabaseError as e:
             raise sqlite3.DatabaseError(
                 f"Database error occurred while inserting DataFrame: {e}"
+            )
+
+        # Keep the date index in place for readers using load(start_date=...).
+        # Done after the write completes: a "replace" write drops the table and
+        # its indexes, so re-creating here is what restores them.
+        #
+        # Indexing is an optimization, so failing to index must not turn a
+        # committed write into a raised error — the caller would otherwise
+        # retry and append the rows a second time. Warn and carry on instead;
+        # queries stay correct without the index, just slower.
+        try:
+            self.create_indexes()
+        except sqlite3.DatabaseError as e:
+            print(
+                f"WARNING: data was written, but indexing table '{self.table}' "
+                f"failed: {e}. Reads will still be correct, but "
+                "load(start_date=...) will not be able to skip rows."
             )
         
     def get_next_run(self):

--- a/tests/unit/test_database_utils.py
+++ b/tests/unit/test_database_utils.py
@@ -1,0 +1,411 @@
+# tests/unit/test_database_utils.py
+"""
+Unit tests for ``CFSDatabase`` loading and indexing in ``src/database_utils.py``.
+
+Strategy: real SQLite databases written to pytest's ``tmp_path``. SQLite is a
+local file, so these are fast and deterministic — no network, no fixtures, no
+mocking of the database layer.
+
+The focus is ``load(start_date=...)``, which pushes the forecast-month filter
+into SQL so notebook 3 does not transfer an entire table across a network
+share. The contract that makes that safe is *equivalence*: the SQL-filtered
+result must match what loading everything and filtering in pandas produces.
+Those equivalence tests are the important ones here.
+"""
+
+import sqlite3
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.data_processor import ForecastTransformer
+from src.database_utils import CFSDatabase
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _year_month_frame():
+    """
+    Build a frame in the ``year``/``month`` layout notebook 2 writes and
+    notebook 3 reads, spanning 2026-05 through 2027-02 so a mid-range
+    threshold has rows on both sides.
+    """
+    months = [
+        (2026, 5), (2026, 6), (2026, 7), (2026, 8), (2026, 12),
+        (2027, 1), (2027, 2),
+    ]
+    return pd.DataFrame({
+        "cfs_run": ["2026050100"] * len(months),
+        "month": [m for _, m in months],
+        "year": [y for y, _ in months],
+        "model": ["RF"] * len(months),
+        "lake": ["erie"] * len(months),
+        "component": ["nbs"] * len(months),
+        "value [mm]": [float(i) for i in range(len(months))],
+    })
+
+
+def _ensemble_frame():
+    """
+    Build an ensemble-shaped frame: many rows sharing each ``(year, month)``.
+
+    The real database holds an ensemble — every forecast month has one row per
+    (cfs_run, model, lake, component) combination, so ``(year, month)`` is far
+    from unique. Fixtures with one row per month cannot catch a filter that
+    collapses duplicates, hence this one: 2 runs x 3 models x 2 lakes x 2
+    components = 24 rows per month.
+    """
+    runs = ["2026010100", "2026010106"]
+    models = ["RF", "GP", "XGB"]
+    lakes = ["superior", "erie"]
+    components = ["precipitation", "nbs"]
+    months = [(2026, 6), (2026, 7), (2027, 1)]
+
+    rows = [
+        (run, month, year, model, lake, component, 1.0)
+        for year, month in months
+        for run in runs
+        for model in models
+        for lake in lakes
+        for component in components
+    ]
+    return pd.DataFrame(rows, columns=[
+        "cfs_run", "month", "year", "model", "lake", "component", "value [mm]",
+    ])
+
+
+def _forecast_month_frame():
+    """Build a frame in the ``forecast_month`` ('YYYY-MM') layout ``pivot`` produces."""
+    fmonths = ["2026-05", "2026-06", "2026-07", "2026-10", "2027-01"]
+    return pd.DataFrame({
+        "cfs_run": ["2026050100"] * len(fmonths),
+        "forecast_month": fmonths,
+        "model": ["RF"] * len(fmonths),
+        "lake": ["erie"] * len(fmonths),
+        "precipitation": [float(i) for i in range(len(fmonths))],
+    })
+
+
+def _write(tmp_path, df, table="cnbs_forecast", name="test.db"):
+    """Write ``df`` to a fresh SQLite database and return its CFSDatabase."""
+    db = CFSDatabase(str(tmp_path / name), table)
+    db.add_df(df)
+    return db
+
+
+def _index_names(database):
+    """Return the user-defined index names present in the database file."""
+    conn = sqlite3.connect(database)
+    try:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+    finally:
+        conn.close()
+
+
+# ===========================================================================
+# load() — backward compatibility
+# ===========================================================================
+class TestLoadUnfiltered:
+    """``load()`` with no arguments keeps its original whole-table behavior."""
+
+    def test_returns_every_row(self, tmp_path):
+        """No start_date means no WHERE clause: all rows come back."""
+        df = _year_month_frame()
+        out = _write(tmp_path, df).load()
+        assert len(out) == len(df)
+
+    def test_preserves_column_order(self, tmp_path):
+        """SELECT * keeps the written column order."""
+        df = _year_month_frame()
+        out = _write(tmp_path, df).load()
+        assert list(out.columns) == list(df.columns)
+
+    def test_works_on_table_without_date_columns(self, tmp_path):
+        """
+        A table with neither layout is still fully loadable — the date columns
+        are only required when start_date is supplied.
+        """
+        df = pd.DataFrame({"cfs_run": ["2026050100"], "value": [1.0]})
+        out = _write(tmp_path, df, table="odd_table").load()
+        assert len(out) == 1
+
+
+# ===========================================================================
+# load(start_date=...) — SQL-side filtering
+# ===========================================================================
+class TestLoadFilteredYearMonth:
+    """
+    On the ``year``/``month`` layout, the filter becomes
+    ``WHERE year > ? OR (year = ? AND month >= ?)``.
+    """
+
+    def test_drops_earlier_months_keeps_later(self, tmp_path):
+        """Rows before the threshold month are excluded; the rest are kept."""
+        out = _write(tmp_path, _year_month_frame()).load(start_date="07-2026")
+        kept = set(zip(out["year"], out["month"]))
+        assert kept == {(2026, 7), (2026, 8), (2026, 12), (2027, 1), (2027, 2)}
+
+    def test_threshold_month_is_inclusive(self, tmp_path):
+        """The start month itself is retained (>=, not >)."""
+        out = _write(tmp_path, _year_month_frame()).load(start_date="07-2026")
+        assert (2026, 7) in set(zip(out["year"], out["month"]))
+
+    def test_year_rollover_not_compared_by_month_alone(self, tmp_path):
+        """
+        January 2027 (month=1) must survive a July 2026 threshold. A naive
+        ``month >= 7`` predicate would wrongly drop it — this pins the
+        (year, month) pair comparison.
+        """
+        out = _write(tmp_path, _year_month_frame()).load(start_date="07-2026")
+        assert (2027, 1) in set(zip(out["year"], out["month"]))
+
+    @pytest.mark.parametrize("start_date", ["07-2026", "2026-07", "2026-07-01"])
+    def test_accepts_the_date_formats_in_use(self, tmp_path, start_date):
+        """
+        ``get_first_forecast_month()`` returns 'MM-YYYY'; 'YYYY-MM' and full
+        dates are also accepted since parsing goes through pandas.Period.
+        """
+        out = _write(tmp_path, _year_month_frame()).load(start_date=start_date)
+        assert len(out) == 5
+
+    def test_threshold_after_all_data_returns_empty(self, tmp_path):
+        """A threshold past every row yields an empty frame, not an error."""
+        out = _write(tmp_path, _year_month_frame()).load(start_date="01-2030")
+        assert out.empty
+
+    def test_threshold_before_all_data_returns_everything(self, tmp_path):
+        """A threshold before every row keeps the whole table."""
+        df = _year_month_frame()
+        out = _write(tmp_path, df).load(start_date="01-2000")
+        assert len(out) == len(df)
+
+
+class TestLoadFilteredForecastMonth:
+    """
+    On the ``forecast_month`` layout the filter is a string comparison, which
+    is only correct because the column is written zero-padded ('2026-07').
+    """
+
+    def test_drops_earlier_months_keeps_later(self, tmp_path):
+        """Rows before the threshold are excluded."""
+        out = _write(tmp_path, _forecast_month_frame()).load(start_date="07-2026")
+        assert set(out["forecast_month"]) == {"2026-07", "2026-10", "2027-01"}
+
+    def test_single_digit_month_sorts_correctly(self, tmp_path):
+        """
+        '2026-10' >= '2026-07' must hold as a string compare. Unpadded values
+        ('2026-7') would break this ordering, so this guards the zero-padding
+        assumption the query relies on.
+        """
+        out = _write(tmp_path, _forecast_month_frame()).load(start_date="07-2026")
+        assert "2026-10" in set(out["forecast_month"])
+
+
+class TestLoadFilteredErrors:
+    """``start_date`` requires a recognizable date layout."""
+
+    def test_raises_when_no_date_columns(self, tmp_path):
+        """A table with neither layout cannot be filtered."""
+        df = pd.DataFrame({"cfs_run": ["2026050100"], "value": [1.0]})
+        db = _write(tmp_path, df, table="odd_table")
+        with pytest.raises(ValueError, match="forecast_month"):
+            db.load(start_date="07-2026")
+
+    def test_start_date_is_bound_as_a_parameter(self, tmp_path):
+        """
+        start_date reaches SQLite as a bound parameter, not interpolated SQL,
+        so a string with quotes cannot alter the query. pandas.Period rejects
+        it before it ever gets that far.
+        """
+        db = _write(tmp_path, _year_month_frame())
+        with pytest.raises(Exception):
+            db.load(start_date="2026-07'; DROP TABLE cnbs_forecast; --")
+        # The table is still intact either way.
+        assert len(db.load()) == len(_year_month_frame())
+
+
+# ===========================================================================
+# Equivalence: SQL pushdown must match filtering in pandas
+# ===========================================================================
+class TestPushdownMatchesPandasFilter:
+    """
+    ``load(start_date=X)`` must return exactly what
+    ``ForecastTransformer(load()).filter(X)`` returns. This is the property
+    that lets notebook 3 push the filter into SQL without changing outputs.
+    """
+
+    @staticmethod
+    def _assert_same(pushed, in_pandas, key):
+        """
+        Compare the two paths on rows, columns and values.
+
+        ``check_dtype=False`` because an empty SQL result comes back with
+        ``object`` columns, while filtering a populated frame down to nothing
+        in pandas preserves the original dtypes. That divergence exists only
+        for empty results and reflects how ``read_sql`` types a zero-row
+        result, not a difference in what gets selected.
+        """
+        pd.testing.assert_frame_equal(
+            pushed.sort_values(key).reset_index(drop=True),
+            in_pandas.sort_values(key).reset_index(drop=True),
+            check_dtype=False,
+        )
+
+    @pytest.mark.parametrize("start_date", ["05-2026", "07-2026", "01-2027", "01-2030"])
+    def test_year_month_layout_matches(self, tmp_path, start_date):
+        """Equivalence across thresholds below, inside, and past the data range."""
+        db = _write(tmp_path, _year_month_frame())
+        self._assert_same(
+            db.load(start_date=start_date),
+            ForecastTransformer(db.load()).filter(start_date),
+            ["year", "month"],
+        )
+
+    @pytest.mark.parametrize("start_date", ["05-2026", "07-2026", "01-2027"])
+    def test_forecast_month_layout_matches(self, tmp_path, start_date):
+        """Same equivalence on the forecast_month layout."""
+        db = _write(tmp_path, _forecast_month_frame())
+        self._assert_same(
+            db.load(start_date=start_date),
+            ForecastTransformer(db.load()).filter(start_date),
+            ["forecast_month"],
+        )
+
+    def test_ensemble_members_all_survive(self, tmp_path):
+        """
+        Every ensemble member of a kept month is returned — the filter selects
+        whole months, it does not collapse rows that share a (year, month).
+        """
+        db = _write(tmp_path, _ensemble_frame())
+        out = db.load(start_date="07-2026")
+
+        per_month = out.groupby(["year", "month"]).size().to_dict()
+        assert per_month == {(2026, 7): 24, (2027, 1): 24}
+
+    def test_ensemble_layout_matches_pandas_filter(self, tmp_path):
+        """Equivalence holds on ensemble-shaped data, duplicates included."""
+        db = _write(tmp_path, _ensemble_frame())
+        self._assert_same(
+            db.load(start_date="07-2026"),
+            ForecastTransformer(db.load()).filter("07-2026"),
+            ["cfs_run", "year", "month", "model", "lake", "component"],
+        )
+
+    def test_dtypes_match_when_rows_survive(self, tmp_path):
+        """
+        For any non-empty result the two paths agree on dtypes too, so the
+        relaxation above is genuinely confined to the empty case.
+        """
+        db = _write(tmp_path, _year_month_frame())
+        pushed = db.load(start_date="07-2026")
+        in_pandas = ForecastTransformer(db.load()).filter("07-2026")
+        assert not pushed.empty
+        assert list(pushed.dtypes) == list(in_pandas.dtypes)
+
+
+# ===========================================================================
+# create_indexes()
+# ===========================================================================
+class TestCreateIndexes:
+    """
+    The index is what makes the WHERE clause reduce I/O — without it SQLite
+    scans every page regardless. ``add_df`` creates it so readers of a shared
+    database do not have to.
+    """
+
+    def test_add_df_indexes_year_month_layout(self, tmp_path):
+        """Writing the year/month layout leaves a (year, month) index behind."""
+        db = _write(tmp_path, _year_month_frame())
+        assert "idx_cnbs_forecast_year_month" in _index_names(db.database)
+
+    def test_add_df_indexes_forecast_month_layout(self, tmp_path):
+        """Writing the forecast_month layout leaves a forecast_month index behind."""
+        db = _write(tmp_path, _forecast_month_frame(), table="pivoted")
+        assert "idx_pivoted_forecast_month" in _index_names(db.database)
+
+    def test_no_index_when_table_has_no_date_columns(self, tmp_path):
+        """Tables without date columns get no index rather than an error."""
+        df = pd.DataFrame({"cfs_run": ["2026050100"], "value": [1.0]})
+        db = _write(tmp_path, df, table="odd_table")
+        assert _index_names(db.database) == set()
+
+    def test_is_idempotent(self, tmp_path):
+        """Repeated calls are safe and converge on the same index set."""
+        db = _write(tmp_path, _year_month_frame())
+        first = db.create_indexes()
+        second = db.create_indexes()
+        assert first == second
+        assert _index_names(db.database) == set(first)
+
+    def test_index_survives_a_replace_write(self, tmp_path):
+        """
+        ``if_exists='replace'`` drops the table *and* its indexes. Because
+        add_df re-indexes after writing, the index is restored.
+        """
+        db = _write(tmp_path, _year_month_frame())
+        db.add_df(_year_month_frame(), if_exists="replace")
+        assert "idx_cnbs_forecast_year_month" in _index_names(db.database)
+
+    def test_index_failure_does_not_discard_the_write(self, tmp_path, capsys):
+        """
+        Indexing is an optimization, so a failure must not surface as an
+        exception from ``add_df`` — the caller would retry and append the rows
+        twice. The data stays written and a warning is printed instead.
+        """
+        df = _year_month_frame()
+        db = CFSDatabase(str(tmp_path / "readonly.db"), "cnbs_forecast")
+
+        with patch.object(
+            CFSDatabase, "create_indexes",
+            side_effect=sqlite3.DatabaseError("attempt to write a readonly database"),
+        ):
+            db.add_df(df)  # must not raise
+
+        assert len(db.load()) == len(df)
+        assert "WARNING" in capsys.readouterr().out
+
+    def test_query_plan_uses_the_index(self, tmp_path):
+        """
+        The point of the index is that a selective filtered query *searches*
+        rather than scans — a plan that says SCAN means the predicate stopped
+        being index-friendly and the network win is gone.
+
+        Uses a table spanning many months and a late threshold, so selecting
+        via the index is unambiguously the cheaper plan. (On a tiny table, or
+        one where the filter matches most rows, SQLite correctly prefers a
+        scan; that choice is not what this test is about.)
+        """
+        months = [(2026, m) for m in range(1, 13)] + [(2027, m) for m in range(1, 13)]
+        rows = months * 40  # ~960 rows, evenly spread across 24 months
+        df = pd.DataFrame({
+            "cfs_run": ["2026010100"] * len(rows),
+            "month": [m for _, m in rows],
+            "year": [y for y, _ in rows],
+            "value [mm]": [1.0] * len(rows),
+        })
+        db = _write(tmp_path, df)
+
+        conn = sqlite3.connect(db.database)
+        try:
+            # ANALYZE so the decision reflects real statistics rather than
+            # the planner's no-stats defaults.
+            conn.execute("ANALYZE")
+            plan = "\n".join(
+                str(row)
+                for row in conn.execute(
+                    "EXPLAIN QUERY PLAN SELECT * FROM cnbs_forecast "
+                    "WHERE year > 2027 OR (year = 2027 AND month >= 12)"
+                )
+            )
+        finally:
+            conn.close()
+
+        assert "idx_cnbs_forecast_year_month" in plan, plan

--- a/tests/unit/test_transformers.py
+++ b/tests/unit/test_transformers.py
@@ -379,3 +379,133 @@ class TestForecastTransformerPivot:
         out = ForecastTransformer(df).pivot()
         forecast_months = set(out["forecast_month"])
         assert {"2024-01", "2024-02"} == forecast_months
+
+
+# ===========================================================================
+# ForecastTransformer.filter — drop forecast months before a threshold
+# ===========================================================================
+class TestForecastTransformerFilter:
+    """
+    ``filter(first_forecast_month)`` keeps rows on or after the given month,
+    working from either a ``forecast_month`` column or a ``year``/``month``
+    pair.
+
+    The ``year``/``month`` branch is compared via integer month ordinals rather
+    than per-row Period objects, so these tests pin the month ordering — in
+    particular that a year rollover is not compared by month number alone.
+    """
+
+    @staticmethod
+    def _year_month_df(pairs):
+        """Build a DataFrame from (year, month) pairs with a running value column."""
+        return pd.DataFrame({
+            "year": [y for y, _ in pairs],
+            "month": [m for _, m in pairs],
+            "value": range(len(pairs)),
+        })
+
+    # --- year / month branch ------------------------------------------------
+    def test_drops_months_before_threshold(self):
+        """Rows earlier than the threshold month are removed."""
+        df = self._year_month_df([(2026, 5), (2026, 6), (2026, 7), (2026, 8)])
+        out = ForecastTransformer(df).filter("07-2026")
+        assert set(zip(out["year"], out["month"])) == {(2026, 7), (2026, 8)}
+
+    def test_threshold_month_is_inclusive(self):
+        """The threshold month itself is kept."""
+        df = self._year_month_df([(2026, 6), (2026, 7)])
+        out = ForecastTransformer(df).filter("07-2026")
+        assert (2026, 7) in set(zip(out["year"], out["month"]))
+
+    def test_year_rollover_kept(self):
+        """
+        January of the following year is after a July threshold. Comparing
+        month numbers alone (1 >= 7 is False) would wrongly drop it.
+        """
+        df = self._year_month_df([(2026, 7), (2027, 1)])
+        out = ForecastTransformer(df).filter("07-2026")
+        assert (2027, 1) in set(zip(out["year"], out["month"]))
+
+    def test_all_data_before_threshold_returns_empty(self):
+        """Nothing survives a threshold later than every row."""
+        df = self._year_month_df([(2025, 1), (2025, 2)])
+        out = ForecastTransformer(df).filter("07-2026")
+        assert out.empty
+
+    def test_all_data_after_threshold_returns_everything(self):
+        """Everything survives a threshold earlier than every row."""
+        df = self._year_month_df([(2027, 1), (2027, 2)])
+        out = ForecastTransformer(df).filter("07-2026")
+        assert len(out) == 2
+
+    def test_keeps_every_ensemble_member_of_a_kept_month(self):
+        """
+        The forecast database holds an ensemble, so many rows share the same
+        ``(year, month)``. Filtering selects whole months and must return all
+        members of each — not one row per month.
+        """
+        df = pd.DataFrame({
+            "year": [2026] * 6 + [2027] * 3,
+            "month": [6, 6, 6, 7, 7, 7, 1, 1, 1],
+            "model": ["RF", "GP", "XGB"] * 3,
+            "value": range(9),
+        })
+        out = ForecastTransformer(df).filter("07-2026")
+
+        assert out.groupby(["year", "month"]).size().to_dict() == {
+            (2026, 7): 3,
+            (2027, 1): 3,
+        }
+        assert sorted(out["model"].unique()) == ["GP", "RF", "XGB"]
+
+    def test_no_helper_column_leaks_into_output(self):
+        """
+        The output columns match the input — no intermediate period/ordinal
+        column is left behind for downstream plotting code to trip over.
+        """
+        df = self._year_month_df([(2026, 7), (2026, 8)])
+        out = ForecastTransformer(df).filter("07-2026")
+        assert list(out.columns) == ["year", "month", "value"]
+
+    def test_dtypes_preserved(self):
+        """Filtering does not re-type the year/month columns."""
+        df = self._year_month_df([(2026, 7), (2026, 8)])
+        out = ForecastTransformer(df).filter("07-2026")
+        assert out["year"].dtype == df["year"].dtype
+        assert out["month"].dtype == df["month"].dtype
+
+    @pytest.mark.parametrize("threshold", ["07-2026", "2026-07", "2026-07-01"])
+    def test_accepts_multiple_threshold_formats(self, threshold):
+        """
+        ``get_first_forecast_month()`` returns 'MM-YYYY'; 'YYYY-MM' and full
+        dates also parse, since the threshold goes through pandas.Period.
+        """
+        df = self._year_month_df([(2026, 6), (2026, 7), (2026, 8)])
+        out = ForecastTransformer(df).filter(threshold)
+        assert len(out) == 2
+
+    # --- forecast_month branch ---------------------------------------------
+    def test_forecast_month_branch_filters(self):
+        """The 'YYYY-MM' column form filters on the same threshold."""
+        df = pd.DataFrame({
+            "forecast_month": ["2026-06", "2026-07", "2026-10", "2027-01"],
+            "value": range(4),
+        })
+        out = ForecastTransformer(df).filter("07-2026")
+        assert set(out["forecast_month"]) == {"2026-07", "2026-10", "2027-01"}
+
+    def test_forecast_month_returned_as_string(self):
+        """
+        The column is handed back as 'YYYY-MM' strings, which is what the
+        plotting code parses with ``format="%Y-%m"``.
+        """
+        df = pd.DataFrame({"forecast_month": ["2026-07", "2026-08"], "value": [0, 1]})
+        out = ForecastTransformer(df).filter("07-2026")
+        assert out["forecast_month"].tolist() == ["2026-07", "2026-08"]
+
+    # --- error path ---------------------------------------------------------
+    def test_raises_without_recognizable_date_columns(self):
+        """A frame with neither layout cannot be filtered."""
+        df = pd.DataFrame({"cfs_run": ["2026070100"], "value": [1.0]})
+        with pytest.raises(ValueError, match="forecast_month"):
+            ForecastTransformer(df).filter("07-2026")


### PR DESCRIPTION
## Description

USACE reports very slow database loading when using the visualization script/notebook. This PR is an attempt to resolve that problem.

Specifically, this PR attempts to improve the performance of loading and filtering CNBS forecast data while preserving existing behavior and notebook outputs.

Changes include:

- Add `CFSDatabase.load(start_date=...)` to push date filtering into SQLite when possible.
- Automatically create database indexes after `add_df()` to support efficient queries.
- Vectorize the `year`/`month` branch of `ForecastTransformer.filter()`, removing  a costly per-row `df.apply()`.
- Update Notebook 3 to use the new `load(start_date=...)` interface. This reuses the existing `start_date` variable in the script/notebook, so it doesn't require the user to do anything different.
- Add regression tests for `ForecastTransformer.filter()` and the new database loading behavior.

On a synthetic 2.1M-row benchmark database, these changes reduced load and filter time from ~39.5 s to ~1.2 s while producing identical outputs.

## Related Issue

Addresses #123

## Context

Investigation showed that the original bottleneck was split between two issues:

1. SQLite performed full table scans without supporting indexes, so SQL filtering alone did not reduce network I/O.
2. The dominant cost was `ForecastTransformer.filter()`, which constructed a `pd.Period` object for every row using `df.apply()`.

This PR addresses both bottlenecks while keeping SQLite as the single source of truth and maintaining backward compatibility.

## Checklist

- [x] Tested locally
- [ ] Documentation updated
- [x] Automated tests added